### PR TITLE
Bug fix for object data type in properties

### DIFF
--- a/htdocs/libraries/icms/properties/Handler.php
+++ b/htdocs/libraries/icms/properties/Handler.php
@@ -848,7 +848,7 @@ abstract class icms_properties_Handler implements Serializable {
     protected function cleanVar($key, $type, $value) {
         switch ($type) {            
             case self::DTYPE_OBJECT:
-                if ($value == null || is_object($value)) {
+                if ($value === null || is_object($value)) {
                     return $value;
                 }
                 if (is_string($value)) {

--- a/htdocs/libraries/icms/properties/Handler.php
+++ b/htdocs/libraries/icms/properties/Handler.php
@@ -848,18 +848,19 @@ abstract class icms_properties_Handler implements Serializable {
     protected function cleanVar($key, $type, $value) {
         switch ($type) {            
             case self::DTYPE_OBJECT:
-                if ($value == null || is_object($value))
+                if ($value == null || is_object($value)) {
                     return $value;
-                if (is_string($value)) {
-                    if (substr($value, 0, 1) == '{')
-                        return json_decode($value, false);
-                    elseif (substr($value, 0, 2) == 'O:')
-                        return unserialize($value);
-                    elseif (class_exists($value, true))
-                        return new $value();
                 }
-                trigger_error('Unknown object class specified', E_USER_WARNING);
-                return null;
+                if (is_string($value)) {
+                    if (substr($value, 0, 1) == '{') {
+                        return json_decode($value, false);
+                    } elseif (substr($value, 0, 2) == 'O:') {
+                        return unserialize($value);
+                    } elseif (class_exists($value, true)) {
+                        return new $value();
+                    }
+                }
+                return (object)$value;
             case self::DTYPE_BOOLEAN:
                 if (is_bool($value))
                     return $value;

--- a/htdocs/libraries/icms/properties/Handler.php
+++ b/htdocs/libraries/icms/properties/Handler.php
@@ -858,6 +858,8 @@ abstract class icms_properties_Handler implements Serializable {
                         return unserialize($value);
                     } elseif (class_exists($value, true)) {
                         return new $value();
+                    } else {
+                        return null;
                     }
                 }
                 return (object)$value;


### PR DESCRIPTION
Few small bugfixes for code used to clean values for DTYPE_OBJECT for properties.

This is also needed to pass one of new PHP Unit tests.