### PR TITLE
Fix Ticket #881.

### DIFF
--- a/htdocs/libraries/jquery/helptip.js
+++ b/htdocs/libraries/jquery/helptip.js
@@ -17,9 +17,9 @@ jQuery("span.helptext").hide();
 
 jQuery('input.checkemall').click(function() {
   if(jQuery(this).is(":checked")) {
-   jQuery(this).parents(".grouped").find("input").attr("checked",true);
+   jQuery(this).parents(".grouped").find("input").prop("checked",true);
   } else {
-   jQuery(this).parents(".grouped").find("input").attr("checked",false);
+   jQuery(this).parents(".grouped").find("input").prop("checked",false);
   }
  });
 });


### PR DESCRIPTION
Lines 20 & 22.
Change: "attr("checked",true)" to "prop("checked",true)" and
"attr("checked",false)" to "prop("checked",false)"
Reason: jQuery 1.6 needs to use 'prop()' function.