### PR TITLE
#903 fix DTYPE_DATETIME conversion handling (right now not all data is converted as should be) 

### DIFF
--- a/htdocs/libraries/icms/db/legacy/updater/Handler.php
+++ b/htdocs/libraries/icms/db/legacy/updater/Handler.php
@@ -177,29 +177,22 @@ class icms_db_legacy_updater_Handler {
         switch ($var[icms_properties_Handler::VARCFG_TYPE]) {
             case icms_properties_Handler::DTYPE_BOOLEAN:
                 return 'TINYINT(1) UNSIGNED';
-                break;
             case icms_properties_Handler::DTYPE_ARRAY:
                 return 'TEXT';
-                break;
             case icms_properties_Handler::DTYPE_OBJECT:
                 return 'MEDIUMTEXT';
-                break;
             case icms_properties_Handler::DTYPE_LIST:
                 return 'VARCHAR(100)';
-                break;
             case icms_properties_Handler::DTYPE_DATETIME:
                 return 'DATETIME';
-                break;
             case icms_properties_Handler::DTYPE_FILE:
                 return 'BLOB';
-                break;
             case icms_properties_Handler::DTYPE_FLOAT:
                 if (isset($var[icms_properties_Handler::VARCFG_MAX_LENGTH]) && ($var[icms_properties_Handler::VARCFG_MAX_LENGTH] > 0)) {
                     return 'FLOAT(' . icms_properties_Handler::VARCFG_MAX_LENGTH . ')';
                 } else {
                     return 'FLOAT';
                 }
-                break;
             case icms_properties_Handler::DTYPE_INTEGER:
                 if (isset($var[icms_properties_Handler::VARCFG_MAX_LENGTH]) && ($var[icms_properties_Handler::VARCFG_MAX_LENGTH] > 0)) {
                     if ($var[icms_properties_Handler::VARCFG_MAX_LENGTH] < 4) {
@@ -216,10 +209,8 @@ class icms_db_legacy_updater_Handler {
                 } else {
                     return 'INT';
                 }
-                break;
             case icms_properties_Handler::DTYPE_LIST:
                 return 'TEXT';
-                break;
             case icms_properties_Handler::DTYPE_STRING:
                 if (isset($var[icms_properties_Handler::VARCFG_MAX_LENGTH])) {
                     if ($var[icms_properties_Handler::VARCFG_MAX_LENGTH] < 500) {
@@ -234,7 +225,6 @@ class icms_db_legacy_updater_Handler {
                 } else {
                     return 'VARCHAR(255)';
                 }
-                break;
             default:
                 return 'TEXT';
         }

--- a/htdocs/libraries/icms/ipf/Object.php
+++ b/htdocs/libraries/icms/ipf/Object.php
@@ -687,12 +687,15 @@ class icms_ipf_Object extends icms_core_Object {
                 continue; // Skipping ID
             }
             if ($this->_vars[$k]['persistent'] === true || $this->_vars[$k]['persistent'] === null) {
+		if ($this->_vars[$k][self::VARCFG_VALUE] === null) {
+		    $fieldsToStoreInDB[$k] = 'NULL';
+		}
                 switch ($this->_vars[$k][self::VARCFG_TYPE]) {
                     case self::DTYPE_FLOAT:                    
                         $fieldsToStoreInDB[$k] = (float)$this->_vars[$k][self::VARCFG_VALUE];
                         break;
                     case self::DTYPE_DATETIME:
-                        $fieldsToStoreInDB[$k] = 'FROM_UNIXTIME(' .  intval($this->_vars[$k][self::VARCFG_VALUE]) . ')';
+			$fieldsToStoreInDB[$k] = $db->quoteString($this->_vars[$k][self::VARCFG_VALUE]->format('Y-m-d H:i:s'));
                         break;                    
                     case self::DTYPE_BOOLEAN:
                     case self::DTYPE_INTEGER:

--- a/htdocs/libraries/icms/properties/Handler.php
+++ b/htdocs/libraries/icms/properties/Handler.php
@@ -513,13 +513,17 @@ abstract class icms_properties_Handler implements Serializable {
      * @return mixed
      */
     public function getVarForEdit($name) {
+	if ($this->_vars[$name][self::VARCFG_VALUE] === null) {
+	    return '';
+	}	
         switch ($this->_vars[$name][self::VARCFG_TYPE]) {
+	    case self::DTYPE_DATETIME: // XOBJ_DTYPE_LTIME
+		return $this->_vars[$name][self::VARCFG_VALUE]->getTimestamp();
             case self::DTYPE_STRING:
             case self::DTYPE_INTEGER: // self::DTYPE_INTEGER
             case self::DTYPE_FLOAT: // XOBJ_DTYPE_FLOAT
             case self::DTYPE_BOOLEAN:
-            case self::DTYPE_FILE: // XOBJ_DTYPE_FILE
-            case self::DTYPE_DATETIME: // XOBJ_DTYPE_LTIME
+            case self::DTYPE_FILE: // XOBJ_DTYPE_FILE            
             case self::DTYPE_ARRAY: // XOBJ_DTYPE_ARRAY            
                 return str_replace(array("&amp;", "&nbsp;"), array('&', '&amp;nbsp;'), @htmlspecialchars((string)$this->_vars[$name][self::VARCFG_VALUE], ENT_QUOTES, _CHARSET));
             case self::DTYPE_LIST: // XOBJ_DTYPE_SIMPLE_ARRAY
@@ -539,13 +543,17 @@ abstract class icms_properties_Handler implements Serializable {
      * @return mixed
      */
     public function getVarForForm($name) {
+	if ($this->_vars[$name][self::VARCFG_VALUE] === null) {
+	    return '';
+	}
         switch ($this->_vars[$name][self::VARCFG_TYPE]) {
+	    case self::DTYPE_DATETIME: // XOBJ_DTYPE_LTIME
+		return $this->_vars[$name][self::VARCFG_VALUE]->getTimestamp();
             case self::DTYPE_STRING:
             case self::DTYPE_INTEGER: // self::DTYPE_INTEGER
             case self::DTYPE_FLOAT: // XOBJ_DTYPE_FLOAT
             case self::DTYPE_BOOLEAN:
-            case self::DTYPE_FILE: // XOBJ_DTYPE_FILE
-            case self::DTYPE_DATETIME: // XOBJ_DTYPE_LTIME
+            case self::DTYPE_FILE: // XOBJ_DTYPE_FILE            
             case self::DTYPE_ARRAY: // XOBJ_DTYPE_ARRAY
             case self::DTYPE_LIST: // XOBJ_DTYPE_SIMPLE_ARRAY
                 return str_replace(array("&amp;", "&nbsp;"), array('&', '&amp;nbsp;'), @htmlspecialchars((string)$this->_vars[$name][self::VARCFG_VALUE], ENT_QUOTES, _CHARSET));

--- a/htdocs/libraries/icms/properties/Handler.php
+++ b/htdocs/libraries/icms/properties/Handler.php
@@ -443,7 +443,11 @@ abstract class icms_properties_Handler implements Serializable {
             case 'n':
             case 'none':
             default:
-                $ret = $this->__get($name);
+		if ($this->_vars[$name][self::VARCFG_TYPE] === self::DTYPE_DATETIME && $this->_vars[$name][self::VARCFG_TYPE] !== null) {
+		    $ret = $this->_vars[$name][self::VARCFG_VALUE]->getTimestamp();
+		} else {
+		    $ret = $this->__get($name);
+		}
         }
         return $ret;
     }
@@ -456,6 +460,9 @@ abstract class icms_properties_Handler implements Serializable {
      * @return mixed
      */
     public function getVarForDisplay($name) {
+	if ($this->_vars[$name][self::VARCFG_VALUE] === null) {
+	    return '-';
+	}
         switch ($this->_vars[$name][self::VARCFG_TYPE]) {
             case self::DTYPE_STRING:
                 if (!isset($this->_vars[$name][self::VARCFG_AF_DISABLED]) || !$this->_vars[$name][self::VARCFG_AF_DISABLED]) {
@@ -488,14 +495,10 @@ abstract class icms_properties_Handler implements Serializable {
             case self::DTYPE_FILE: // XOBJ_DTYPE_FILE                    
                 return str_replace(array("&amp;", "&nbsp;"), array('&', '&amp;nbsp;'), @htmlspecialchars($this->_vars[$name][self::VARCFG_VALUE], ENT_QUOTES, _CHARSET));
             case self::DTYPE_DATETIME: // XOBJ_DTYPE_LTIME
-		if ($this->_vars[$name][self::VARCFG_VALUE] instanceof \DateTimeInterface) {
-		    if (isset($this->_vars[$name][self::VARCFG_FORMAT]) === false) {
-			$this->_vars[$name][self::VARCFG_FORMAT] = 'r';
-		    }
-		    return $this->_vars[$name][self::VARCFG_VALUE]->format($this->_vars[$name][self::VARCFG_FORMAT]);
-		} else {
-		    return '-';
+		if (isset($this->_vars[$name][self::VARCFG_FORMAT]) === false) {
+		    $this->_vars[$name][self::VARCFG_FORMAT] = 'r';
 		}
+		return $this->_vars[$name][self::VARCFG_VALUE]->format($this->_vars[$name][self::VARCFG_FORMAT]);
             case self::DTYPE_ARRAY: // XOBJ_DTYPE_ARRAY
                 return $this->_vars[$name][self::VARCFG_VALUE];            
             case self::DTYPE_LIST; // XOBJ_DTYPE_SIMPLE_ARRAY

--- a/htdocs/libraries/icms/properties/Handler.php
+++ b/htdocs/libraries/icms/properties/Handler.php
@@ -950,19 +950,20 @@ abstract class icms_properties_Handler implements Serializable {
                 }
                 return null;
             case self::DTYPE_DATETIME:
-                if (is_int($value))
-                    return $value;
-                if ($value === null)
-                    return 0;                
-                if (is_numeric($value))
-                    return intval($value);
-                if (!is_string($value))
-                    return 0;
-                if (preg_match('/(\d\d\d\d)-(\d\d)-(\d\d) (\d\d):(\d\d):(\d\d)/ui', $value, $ret))
-                    $time = gmmktime($ret[4], $ret[5], $ret[6], $ret[2], $ret[3], $ret[1]);
-                else
-                    $time = (int) strtotime($value);
-                return ($time < 0) ? 0 : $time;
+		if (($value instanceof \DateTimeInterface) || ($value === null)) {
+		    return $value;
+		}
+		if (is_numeric($value)) {
+		    return new \DateTime('@' . $value);
+		}
+                if (!is_string($value)) {
+                    return null;
+		}
+		try {
+		    return new \DateTime($value);
+		} catch (\Exception $ex) {
+		    return null;
+		}
             case self::DTYPE_STRING:
             default:
                 if (!is_string($value)) {

--- a/htdocs/libraries/icms/properties/Handler.php
+++ b/htdocs/libraries/icms/properties/Handler.php
@@ -430,26 +430,22 @@ abstract class icms_properties_Handler implements Serializable {
             case 'show':
             case 'p':
             case 'preview':
-                $ret = $this->getVarForDisplay($name);
-                break;
+                return $this->getVarForDisplay($name);
             case 'e':
             case 'edit':
-                $ret = $this->getVarForEdit($name);
-                break;
+                return $this->getVarForEdit($name);
             case 'f':
             case 'formpreview':
-                $ret = $this->getVarForForm($name);
-                break;
+                return $this->getVarForForm($name);
             case 'n':
             case 'none':
             default:
 		if ($this->_vars[$name][self::VARCFG_TYPE] === self::DTYPE_DATETIME && $this->_vars[$name][self::VARCFG_TYPE] !== null) {
-		    $ret = $this->_vars[$name][self::VARCFG_VALUE]->getTimestamp();
+		    return $this->_vars[$name][self::VARCFG_VALUE]->getTimestamp();
 		} else {
-		    $ret = $this->__get($name);
+		    return $this->__get($name);
 		}
         }
-        return $ret;
     }
 
     /**

--- a/htdocs/libraries/icms/properties/Handler.php
+++ b/htdocs/libraries/icms/properties/Handler.php
@@ -488,7 +488,14 @@ abstract class icms_properties_Handler implements Serializable {
             case self::DTYPE_FILE: // XOBJ_DTYPE_FILE                    
                 return str_replace(array("&amp;", "&nbsp;"), array('&', '&amp;nbsp;'), @htmlspecialchars($this->_vars[$name][self::VARCFG_VALUE], ENT_QUOTES, _CHARSET));
             case self::DTYPE_DATETIME: // XOBJ_DTYPE_LTIME
-                return date(isset($this->_vars[$name][self::VARCFG_FORMAT]) ? $this->_vars[$name][self::VARCFG_FORMAT] : 'r', $this->_vars[$name][self::VARCFG_VALUE]);
+		if ($this->_vars[$name][self::VARCFG_VALUE] instanceof \DateTimeInterface) {
+		    if (isset($this->_vars[$name][self::VARCFG_FORMAT]) === false) {
+			$this->_vars[$name][self::VARCFG_FORMAT] = 'r';
+		    }
+		    return $this->_vars[$name][self::VARCFG_VALUE]->format($this->_vars[$name][self::VARCFG_FORMAT]);
+		} else {
+		    return '-';
+		}
             case self::DTYPE_ARRAY: // XOBJ_DTYPE_ARRAY
                 return $this->_vars[$name][self::VARCFG_VALUE];            
             case self::DTYPE_LIST; // XOBJ_DTYPE_SIMPLE_ARRAY
@@ -514,7 +521,7 @@ abstract class icms_properties_Handler implements Serializable {
             case self::DTYPE_FILE: // XOBJ_DTYPE_FILE
             case self::DTYPE_DATETIME: // XOBJ_DTYPE_LTIME
             case self::DTYPE_ARRAY: // XOBJ_DTYPE_ARRAY            
-                return str_replace(array("&amp;", "&nbsp;"), array('&', '&amp;nbsp;'), @htmlspecialchars($this->_vars[$name][self::VARCFG_VALUE], ENT_QUOTES, _CHARSET));
+                return str_replace(array("&amp;", "&nbsp;"), array('&', '&amp;nbsp;'), @htmlspecialchars((string)$this->_vars[$name][self::VARCFG_VALUE], ENT_QUOTES, _CHARSET));
             case self::DTYPE_LIST: // XOBJ_DTYPE_SIMPLE_ARRAY
                 return $this->getVar($name, 'n');
                 break;
@@ -541,7 +548,7 @@ abstract class icms_properties_Handler implements Serializable {
             case self::DTYPE_DATETIME: // XOBJ_DTYPE_LTIME
             case self::DTYPE_ARRAY: // XOBJ_DTYPE_ARRAY
             case self::DTYPE_LIST: // XOBJ_DTYPE_SIMPLE_ARRAY
-                return str_replace(array("&amp;", "&nbsp;"), array('&', '&amp;nbsp;'), @htmlspecialchars($this->_vars[$name][self::VARCFG_VALUE], ENT_QUOTES, _CHARSET));
+                return str_replace(array("&amp;", "&nbsp;"), array('&', '&amp;nbsp;'), @htmlspecialchars((string)$this->_vars[$name][self::VARCFG_VALUE], ENT_QUOTES, _CHARSET));
             case self::DTYPE_OTHER: // XOBJ_DTYPE_OTHER
             case self::DTYPE_OBJECT:
             default:
@@ -628,7 +635,7 @@ abstract class icms_properties_Handler implements Serializable {
             case self::DTYPE_STRING:
                 return strlen($this->_vars[$key][self::VARCFG_VALUE]) > 0;
             case self::DTYPE_DATETIME:
-                return is_int($this->_vars[$key][self::VARCFG_VALUE]) && ($this->_vars[$key][self::VARCFG_VALUE] > 0);
+                return $this->_vars[$key][self::VARCFG_VALUE] instanceof \DateTimeInterface;
         }
     }
 

--- a/tests/libraries/icms/PropertiesTest.php
+++ b/tests/libraries/icms/PropertiesTest.php
@@ -100,7 +100,7 @@ class PropertiesTest extends \PHPUnit_Framework_TestCase {
         
         foreach ([[52], [59 => 'aaa'], true, 1, 1.0, -9, 'test', [], new \stdClass(), function () {}] as $v) {
             $mock->v = $v;
-            $this->assertTrue(is_int($mock->v) || (is_object($mock->v) && $mock->v instanceof \DateTime), 'DTYPE_DATETIME must convert all data');
+            $this->assertTrue(is_null($mock->v) || (is_object($mock->v) && $mock->v instanceof \DateTime), 'DTYPE_DATETIME must convert all data');
         }
     }    
     


### PR DESCRIPTION
This is needed to pass phpunit tests

Also, right now DATETIME data is storied internally not as integer but as \DateTime to do easier operations with data (less conversion needed when doing some datetime operations).