### PR TITLE
Adjustments for the composer autoload and class_alias - #915

### DIFF
--- a/htdocs/composer.json
+++ b/htdocs/composer.json
@@ -22,8 +22,7 @@
     "php": ">=5.4.8"
   },
   "autoload": {
-    "classmap": [ "libraries/icms/", "modules",
-      "libraries/icms.php"
-    ]
+    "psr-0" : {"" : "libraries/"},
+    "classmap": [ "modules"]
   }
 }

--- a/htdocs/modules/system/class/AvatarsHandler.php
+++ b/htdocs/modules/system/class/AvatarsHandler.php
@@ -3,8 +3,29 @@
  * wrapper class for handling the avatars
  *
  * @copyright 	The ImpressCMS Project <http://www.impresscms.org>
- * @license	GNU General Public License (GPL) <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+ * @license		GNU General Public License (GPL) <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
  * @package     ImpressCMS\Modules\System\Class\Avatars
- * @see         \icms_data_avatar_Handler
  */
-class_alias('icms_data_avatar_Handler', 'mod_system_AvatarsHandler', true);
+
+/**
+ * Handler for avatars
+ * @category	ICMS
+ * @package		Administration
+ * @subpackage	Avatars
+ */
+class mod_system_AvatarsHandler extends icms_data_avatar_Handler {
+
+	/**
+	 *
+	 * Constructs the avatar handler
+	 *
+	 * @param obj $db	database instance (@see icms_db_Factory::instance)
+	 */
+	public function __construct(&$db) {
+		parent::__construct($db);
+		/* overriding the default table name
+		 * @todo	complete refactoring and use standard table name
+		 */
+		$this->table = $this->db->prefix('avatar');
+	}
+}

--- a/htdocs/modules/system/class/CommentsHandler.php
+++ b/htdocs/modules/system/class/CommentsHandler.php
@@ -3,8 +3,30 @@
  * wrapper class for handling comments
  *
  * @copyright 	The ImpressCMS Project <http://www.impresscms.org>
- * @license	GNU General Public License (GPL) <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+ * @license		GNU General Public License (GPL) <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
  * @package     ImpressCMS\Modules\System\Class\Comments
- * @see         \icms_data_comment_Handler
  */
-class_alias('icms_data_comment_Handler', 'mod_system_CommentsHandler', true);
+
+/**
+ * Handler for comments
+ *
+ * @category	ICMS
+ * @package		Administration
+ * @subpackage	Comments
+ */
+class mod_system_CommentsHandler extends icms_data_comment_Handler {
+
+	/**
+	 *
+	 * Constructs the comment handler
+	 *
+	 * @param obj $db	database instance (@see icms_db_Factory::instance)
+	 */
+	public function __construct(&$db) {
+		parent::__construct($db);
+		/* overriding the default table name
+		 * @todo	complete refactoring and use standard table name
+		 */
+		$this->table = $this->db->prefix('xoopscomments');
+	}
+}

--- a/htdocs/modules/system/class/GroupsHandler.php
+++ b/htdocs/modules/system/class/GroupsHandler.php
@@ -3,8 +3,29 @@
  * Wrapper for administering groups
  *
  * @copyright 	The ImpressCMS Project <http://www.impresscms.org>
- * @license	GNU General Public License (GPL) <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+ * @license		GNU General Public License (GPL) <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
  * @package     ImpressCMS\Modules\System\Class\Groups
- * @see         \icms_member_group_Handler
  */
-class_alias('icms_member_group_Handler', 'mod_system_GroupsHandler', true);
+
+/**
+ * Handles group administration
+ *
+ * @category	ICMS
+ * @package		Administration
+ * @subpackage	Groups
+ */
+class mod_system_GroupsHandler extends icms_member_group_Handler {
+
+	/**
+	 * Constructs the handler class for groups
+	 *
+	 * @param  obj $db	database instance (@see icms_db_Factory::instance)
+	 */
+	public function __construct(&$db) {
+		parent::__construct($db);
+		/* overriding the default table name
+		 * @todo	complete refactoring and use standard table name
+		 */
+		$this->table = $this->db->prefix('groups');
+	}
+}

--- a/htdocs/modules/system/class/ImagesHandler.php
+++ b/htdocs/modules/system/class/ImagesHandler.php
@@ -3,8 +3,28 @@
  * wrapper for image management
  *
  * @copyright	http://www.impresscms.org/ The ImpressCMS Project
- * @license	LICENSE.txt
- * @see         \icms_image_Handler
+ * @license		LICENSE.txt
  * @package     ImpressCMS\Modules\System\Class\Images
  */
-class_alias('icms_image_Handler', 'mod_system_ImagesHandler', true);
+
+/**
+ * Handler for managing images
+
+ * @category	ICMS
+ * @package		Administration
+ * @subpackage	Images
+ */
+class mod_system_ImagesHandler extends icms_image_Handler {
+
+	/**
+	 * Construct the handler
+	 * @@param  obj $db	database instance (@see icms_db_Factory::instance)
+	 */
+	public function __construct(&$db) {
+		parent::__construct($db);
+		/* overriding the default table name
+		 * @todo	complete refactoring and use standard table name
+		 */
+		$this->table = $this->db->prefix('images');
+	}
+}

--- a/htdocs/modules/system/class/ModulesHandler.php
+++ b/htdocs/modules/system/class/ModulesHandler.php
@@ -3,8 +3,28 @@
  * wrapper class for handling the module objects
  *
  * @copyright 	The ImpressCMS Project <http://www.impresscms.org>
- * @license	GNU General Public License (GPL) <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+ * @license		GNU General Public License (GPL) <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
  * @package     ImpressCMS\Modules\System\Class\Modules
- * @see         \icms_module_Handler
  */
-class_alias('icms_module_Handler', 'mod_system_ModulesHandler', true);
+
+/**
+ * Handler for modules
+ * @category	ICMS
+ * @package		Administration
+ * @subpackage	Modules
+ */
+class mod_system_ModulesHandler extends icms_module_Handler {
+
+	/**
+	 * Constructs the handler for modules
+	 *
+	 * @param obj $db
+	 */
+	public function __construct(&$db) {
+		parent::__construct($db);
+		/* overriding the table name
+		 * @todo	complete refactoring and use standard database table name
+		 */
+		$this->table = $this->db->prefix('modules');
+	}
+}

--- a/htdocs/modules/system/class/TplsetsHandler.php
+++ b/htdocs/modules/system/class/TplsetsHandler.php
@@ -3,8 +3,28 @@
  * wrapper for template management
  *
  * @copyright	http://www.impresscms.org/ The ImpressCMS Project
- * @license	LICENSE.txt
+ * @license		LICENSE.txt
  * @package     ImpressCMS\Modules\System\Class\TemplatesSets
- * @see         \icms_view_template_set_Handler
  */
-class_alias('icms_view_template_set_Handler', 'mod_system_TplsetsHandler', true);
+
+/**
+ * Handler for managing images
+
+ * @category	ICMS
+ * @package		Administration
+ * @subpackage	Templates
+ */
+class mod_system_TplsetsHandler extends icms_view_template_set_Handler {
+
+	/**
+	 * Construct the handler
+	 * @@param  obj $db	database instance (@see icms_db_Factory::instance)
+	 */
+	public function __construct(&$db) {
+		parent::__construct($db);
+		/* overriding the default table name
+		 * @todo	complete refactoring and use standard table name
+		 */
+		$this->table = $this->db->prefix('tplset');
+	}
+}

--- a/htdocs/modules/system/class/Userrank.php
+++ b/htdocs/modules/system/class/Userrank.php
@@ -3,15 +3,81 @@
  * ImpressCMS Userranks
  *
  * @copyright	The ImpressCMS Project http://www.impresscms.org/
- * @license	http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License (GPL)
- * @since	1.2
- * @author	Sina Asghari (aka stranger) <pesian_stranger@users.sourceforge.net>
+ * @license		http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License (GPL)
+ * @since		1.2
+ * @author		Sina Asghari (aka stranger) <pesian_stranger@users.sourceforge.net>
  */
 
 defined("ICMS_ROOT_PATH") or die ("ImpressCMS root path not defined");
 
+icms_loadLanguageFile("system", "common");
+icms_loadLanguageFile("system", "userrank", TRUE);
+
 /**
- * @package     ImpressCMS\Modules\System\Class\Rank
- * @see         \icms_member_rank_Object
+ * Ranks to assign members
+ * 
+ * @package		System
+ * @subpackage	Users
  */
-class_alias('icms_member_rank_Object', 'mod_system_Userrank', true);
+class mod_system_Userrank extends icms_ipf_Object {
+
+	/** */
+	public $content = FALSE;
+
+	/**
+	 * Create a new instance of the userrank object
+	 * 
+	 * @param object $handler
+	 */
+	public function __construct(&$handler) {
+		parent::__construct($handler);
+
+		$this->quickInitVar("rank_id", self::DTYPE_INTEGER, TRUE);
+		$this->quickInitVar("rank_title", self::DTYPE_DEP_TXTBOX, TRUE, _CO_ICMS_USERRANK_RANK_TITLE, _CO_ICMS_USERRANK_RANK_TITLE_DSC);
+		$this->quickInitVar("rank_min", self::DTYPE_INTEGER, TRUE, _CO_ICMS_USERRANK_RANK_MIN, _CO_ICMS_USERRANK_RANK_MIN_DSC);
+		$this->quickInitVar("rank_max", self::DTYPE_INTEGER, TRUE, _CO_ICMS_USERRANK_RANK_MAX, _CO_ICMS_USERRANK_RANK_MAX_DSC);
+		$this->quickInitVar("rank_special", self::DTYPE_INTEGER, TRUE, _CO_ICMS_USERRANK_RANK_SPECIAL, _CO_ICMS_USERRANK_RANK_SPECIAL_DSC);
+		$this->quickInitVar("rank_image", self::DTYPE_DEP_TXTBOX, TRUE, _CO_ICMS_USERRANK_RANK_IMAGE, _CO_ICMS_USERRANK_RANK_IMAGE_DSC);
+
+		$this->setControl("rank_special", "yesno");
+		$this->setControl("rank_image", "image");
+	}
+
+	/**
+	 * (non-PHPdoc)
+	 * @see htdocs/libraries/icms/ipf/icms_ipf_Object::getVar()
+	 */
+	public function getVar($key, $format = "s") {
+		if ($format == "s" && in_array($key, array())) {
+			return call_user_func(array($this, $key));
+		}
+		return parent::getVar($key, $format);
+	}
+
+	/**
+	 * Create a link for cloning the object
+	 * @return	str
+	 */
+	public function getCloneLink() {
+		$ret = '<a href="' . ICMS_MODULES_URL . '/system/admin.php?fct=userrank&amp;op=clone&amp;rank_id=' . $this->id() . '"><img src="' . ICMS_IMAGES_SET_URL . '/actions/editcopy.png" style="vertical-align: middle;" alt="' . _CO_ICMS_CUSTOMTAG_CLONE . '" title="' . _CO_ICMS_CUSTOMTAG_CLONE . '" /></a>';
+		return $ret;
+	}
+
+	/**
+	 * Create a link to the image for the rank
+	 * @return	str
+	 */
+	public function getRankPicture() {
+		$ret = '<img src="' . $this->handler->getImageUrl() . $this->getVar("rank_image") . '" />';
+		return $ret;
+	}
+
+	/**
+	 * Accessor for the rank_title property
+	 * @return	str
+	 */
+	public function getRankTitle() {
+		$ret = $this->getVar("rank_title");
+		return $ret;
+	}
+}

--- a/htdocs/modules/system/class/UserrankHandler.php
+++ b/htdocs/modules/system/class/UserrankHandler.php
@@ -3,15 +3,92 @@
  * ImpressCMS Userrank Handler
  *
  * @copyright	The ImpressCMS Project http://www.impresscms.org/
- * @license	http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License (GPL)
- * @since	1.2
- * @author	Sina Asghari (aka stranger) <pesian_stranger@users.sourceforge.net>
+ * @license		http://www.gnu.org/licenses/old-licenses/gpl-2.0.html GNU General Public License (GPL)
+ * @since		1.2
+ * @author		Sina Asghari (aka stranger) <pesian_stranger@users.sourceforge.net>
  */
 
 defined("ICMS_ROOT_PATH") or die ("ImpressCMS root path not defined");
 
+icms_loadLanguageFile("system", "common");
+icms_loadLanguageFile("system", "userrank", TRUE);
+
 /**
- * @package     ImpressCMS\Modules\System\Class\Rank
- * @see         \icms_member_rank_Handler
+ * Handler for the user ranks object
+ *
+ * @package		System
+ * @subpackage	Users
  */
-class_alias('icms_member_rank_Handler', 'mod_system_UserrankHandler', true);
+class mod_system_UserrankHandler extends icms_ipf_Handler {
+	
+	/** */
+	public $objects = FALSE;
+
+	/**
+	 * Create a new instance of the handler
+	 *
+	 * @param object $db
+	 */
+	public function __construct($db) {
+		global $icmsConfigUser;
+		parent::__construct($db, "userrank", "rank_id", "rank_title", "", "system");
+		$this->table = $this->db->prefix("ranks");
+		$this->enableUpload(array("image/gif", "image/jpeg", "image/pjpeg", "image/x-png", "image/png"), $icmsConfigUser["rank_maxsize"], $icmsConfigUser["rank_width"], $icmsConfigUser["rank_height"]);
+	}
+
+	/**
+	 *
+	 *
+	 * @param	int 	$rank_id
+	 * @param	int 	$posts
+	 * @return	array
+	 */
+	public function getRank($rank_id = 0, $posts = 0) {
+		$rank_id = (int) $rank_id;
+		$posts = (int) $posts;
+
+		$criteria = new icms_db_criteria_Compo();
+		if ($rank_id != 0) {
+			$criteria->add(new icms_db_criteria_Item("rank_id", $rank_id));
+		} else {
+			$criteria->add(new icms_db_criteria_Item("rank_min", $posts, "<="));
+			$criteria->add(new icms_db_criteria_Item("rank_max", $posts, ">="));
+			$criteria->add(new icms_db_criteria_Item("rank_special", "0"));
+		}
+
+		$ranks = $this->getObjects($criteria);
+		if (count($ranks) != 1) {
+			$rank = array(
+				"id" => 0,
+				"title" => "",
+				"image" => ICMS_UPLOAD_URL . "blank.gif");
+		} else {
+			$rank = array(
+				"id" => $rank_id,
+				"title" => $ranks[0]->getVar("rank_title"),
+				"image" => $this->getImageUrl() . $ranks[0]->getVar("rank_image"));
+		}
+
+		return $rank;
+	}
+
+	/**
+	 * Relocate images for ranks from previous location
+	 * @return	bool
+	 */
+	public function MoveAllRanksImagesToProperPath() {
+		$sql = "SELECT rank_image FROM " . $this->table;
+		$Query = $this->query($sql, FALSE);
+		for ($i = 0; $i < count($Query); $i++) {
+			$values[] = $Query[$i]["rank_image"];
+		}
+
+		foreach ($values as $value) {
+			if (file_exists(ICMS_UPLOAD_PATH . "/" . $value)) {
+				icms_core_Filesystem::copyRecursive(ICMS_UPLOAD_PATH . "/" . $value, $this->getImagePath() . $value);
+			}
+		}
+
+		return TRUE;
+	}
+}

--- a/htdocs/modules/system/class/UsersHandler.php
+++ b/htdocs/modules/system/class/UsersHandler.php
@@ -3,8 +3,29 @@
  * wrapper class for handling users
  *
  * @copyright 	The ImpressCMS Project <http://www.impresscms.org>
- * @license	GNU General Public License (GPL) <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
+ * @license		GNU General Public License (GPL) <http://www.gnu.org/licenses/old-licenses/gpl-2.0.html>
  * @package     ImpressCMS\Modules\System\Class\Users
- * @see         \icms_member_user_Handler
  */
-class_alias('icms_member_user_Handler', 'mod_system_UsersHandler', true);
+
+/**
+ * Handler for comments
+ *
+ * @category	ICMS
+ * @package		Administration
+ * @subpackage	Users
+ */
+class mod_system_UsersHandler extends icms_member_user_Handler {
+
+	/**
+	 * Constructs the comment handler
+	 *
+	 * @param obj $db	database instance (@see icms_db_Factory::instance)
+	 */
+	public function __construct(&$db) {
+		parent::__construct($db);
+		/* overriding the default table name
+		 * @todo	complete refactoring and use standard table name
+		 */
+		$this->table = $this->db->prefix('users');
+	}
+}


### PR DESCRIPTION
Classes reverted to have standard declarations instead of class_aliases, so composer can properly add them to its autoloader. 

Also - the icms library is PSR-0 compliant, so we can define that in composer.json

Ref #915