### PR TITLE
Icons in readme.md improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![GitHub license](https://img.shields.io/badge/license-GPL-blue.svg?style=flat)](https://raw.githubusercontent.com/ImpressCMS/impresscms/retro/License.txt)
-[![Build Status](https://scrutinizer-ci.com/g/ImpressCMS/impresscms/badges/build.png?b=retro)](https://scrutinizer-ci.com/g/ImpressCMS/impresscms/build-status/retro)
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/ImpressCMS/impresscms/badges/quality-score.png?b=retro)](https://scrutinizer-ci.com/g/ImpressCMS/impresscms/?branch=retro)
+[![License](https://img.shields.io/github/license/ImpressCMS/impresscms.svg?maxAge=2592000)](License.txt) [![GitHub release](https://img.shields.io/github/release/ImpressCMS/impresscms.svg?maxAge=2592000)](https://github.com/ImpressCMS/impresscms/releases) [![Build Status](https://scrutinizer-ci.com/g/ImpressCMS/impresscms/badges/build.png?b=retro)](https://scrutinizer-ci.com/g/ImpressCMS/impresscms/build-status/retro) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/ImpressCMS/impresscms/badges/quality-score.png?b=retro)](https://scrutinizer-ci.com/g/ImpressCMS/impresscms/?branch=retro)
 
 # ImpressCMS
 


### PR DESCRIPTION
Added icon with latest release number and license now autodetected for icon from repo (if we change our license, we just need to update License.txt file with new one... at least for readme.md)