### PR TITLE
Fixes warning with invalid index 'options'

### DIFF
--- a/htdocs/libraries/icms/core/DataFilter.php
+++ b/htdocs/libraries/icms/core/DataFilter.php
@@ -406,10 +406,10 @@ class icms_core_DataFilter {
 	static public function checkVarArray(array $input, array $filters, $strict = TRUE) {
 		foreach (array_intersect_key($input, $filters) as $key => $value) {
 			$options[0] = $options[1] = '';
-			if (isset($filters[$key]['options'][0])) {
+			if (array_key_exists('options', $filters) && isset($filters[$key]['options'][0])) {
 				$options[0] = $filters[$key]['options'][0];
 			}
-			if (isset($filters[$key]['options'][1])) {
+			if (array_key_exists('options', $filters) && isset($filters[$key]['options'][1])) {
 				$options[1] = $filters[$key]['options'][1];
 			}
 			if (is_array($filters[$key])) {


### PR DESCRIPTION
(noticed at the top of every page - buildRelevantUrls was the calling function)

test #920