### PR TITLE
Use reg users group if no default module/page set

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -75,12 +75,12 @@ if (preg_match_all('|([^/]+)/([^/]+)/([^/]+)(.*)|', $path, $params, PREG_SET_ORD
     );
 
     // added failover to default startpage for the registered users group -- JULIAN EGELSTAFF Apr 3 2017
-	$groups = (!empty(\icms::$user) && is_object(\icms::$user)) ? \icms::$user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+	$groups = (!empty(\icms::$user) && is_object(\icms::$user)) ? \icms::$user->getGroups() : array(ICMS_GROUP_ANONYMOUS);
 	if(($icmsConfig['startpage'][$group] == "" OR $icmsConfig['startpage'][$group] == "--") 
-	AND in_array(XOOPS_GROUP_USERS, $groups) 
-	AND $icmsConfig['startpage'][XOOPS_GROUP_USERS] != "" 
-	AND $icmsConfig['startpage'][XOOPS_GROUP_USERS] != "--") {
-		$icmsConfig['startpage'] = $icmsConfig['startpage'][XOOPS_GROUP_USERS];
+	AND in_array(ICMS_GROUP_USERS, $groups) 
+	AND $icmsConfig['startpage'][ICMS_GROUP_USERS] != "" 
+	AND $icmsConfig['startpage'][ICMS_GROUP_USERS] != "--") {
+		$icmsConfig['startpage'] = $icmsConfig['startpage'][ICMS_GROUP_USERS];
 	} else {
 		$icmsConfig['startpage'] = $icmsConfig['startpage'][$group];
 	}

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -74,7 +74,16 @@ if (preg_match_all('|([^/]+)/([^/]+)/([^/]+)(.*)|', $path, $params, PREG_SET_ORD
         (!empty(\icms::$user) && is_object(\icms::$user)) ? \icms::$user->uid : 0
     );
 
-    $icmsConfig['startpage'] = $icmsConfig['startpage'][$group];
+    // added failover to default startpage for the registered users group -- JULIAN EGELSTAFF Apr 3 2017
+	$groups = (!empty(\icms::$user) && is_object(\icms::$user)) ? \icms::$user->getGroups() : array(XOOPS_GROUP_ANONYMOUS);
+	if(($icmsConfig['startpage'][$group] == "" OR $icmsConfig['startpage'][$group] == "--") 
+	AND in_array(XOOPS_GROUP_USERS, $groups) 
+	AND $icmsConfig['startpage'][XOOPS_GROUP_USERS] != "" 
+	AND $icmsConfig['startpage'][XOOPS_GROUP_USERS] != "--") {
+		$icmsConfig['startpage'] = $icmsConfig['startpage'][XOOPS_GROUP_USERS];
+	} else {
+		$icmsConfig['startpage'] = $icmsConfig['startpage'][$group];
+	}
 
     if (isset($icmsConfig['startpage']) && $icmsConfig['startpage'] != '' && $icmsConfig['startpage'] != '--') {
         $arr = explode('-', $icmsConfig['startpage']);


### PR DESCRIPTION
Currently, if the Registered Users group has a default module/page set, it is ignored if the user is a member of another group that has no default module/page set.

Perhaps the Registered Users group should be used as a failsafe, so that you don't have to set default pages for every single group in your site? The only downside I can see is that perhaps webmasters would have specifically set a certain group to have no default page and intend that as the behaviour for that group. I think it's more powerful to rely on Registered Users to avoid people having to set a default page for every group though. Especially on sites with many many groups.