### PR TITLE
A bit more improved listing php extensions in composer.json

### DIFF
--- a/htdocs/composer.json
+++ b/htdocs/composer.json
@@ -30,12 +30,12 @@
     "ext-session": "*"
   },
   "suggest": {
-    "ext-iconv": "*",
-    "ext-xml": "*",
-    "ext-openssl": "*",
-    "ext-bcmath": "*",
-    "ext-PDO": "*",
-    "ext-mysql": "*"
+    "ext-iconv": "Iconv is needed to handle conversions between charsets",
+    "ext-xml": "Faster way then with PHP scripts to handle XML documents",
+    "ext-openssl": "Without it OpenID will not work",
+    "ext-bcmath": "Better precistions in math operations",
+    "ext-PDO": "Use it if you would like to use PDO driver for database",
+    "ext-mysql": "Use it if you would like to use old driver for MySQL (only for PHP 5.x)"
   },
   "autoload": {
     "psr-0" : {"" : "libraries/"},

--- a/htdocs/composer.json
+++ b/htdocs/composer.json
@@ -23,13 +23,19 @@
     "simplepie/simplepie": "1.3.1",
     "ezyang/htmlpurifier": "4.6.*",
     "ext-curl": "*",
-    "ext-mbstring": "*",
-    "ext-iconv": "*",
     "ext-gd": "*",
+    "ext-json": "*",
+    "ext-mbstring": "*",
+    "ext-pcre": "*",
+    "ext-session": "*"
+  },
+  "suggest": {
+    "ext-iconv": "*",
     "ext-xml": "*",
     "ext-openssl": "*",
-    "ext-json": "*",
+    "ext-bcmath": "*",
     "ext-PDO": "*"
+    "ext-mysql": "*"
   },
   "autoload": {
     "psr-0" : {"" : "libraries/"},

--- a/htdocs/composer.json
+++ b/htdocs/composer.json
@@ -34,7 +34,7 @@
     "ext-xml": "*",
     "ext-openssl": "*",
     "ext-bcmath": "*",
-    "ext-PDO": "*"
+    "ext-PDO": "*",
     "ext-mysql": "*"
   },
   "autoload": {


### PR DESCRIPTION
In previous pull request I have added some PHP extensions in required list, however some of them are optional.