### PR TITLE
SPDX license in composer.json fix

### DIFF
--- a/htdocs/composer.json
+++ b/htdocs/composer.json
@@ -3,7 +3,7 @@
   "type": "project",
   "description": "ImpressCMS is an open source content management system with a focus on security and speed",
   "minimum-stability": "dev",
-  "license": "GPLv2",
+  "license": "GPL-2.0-only",
   "authors": [
     {
       "name": "marcan"


### PR DESCRIPTION
I don't know where this is used but at least when running `composer validate` we got warning:

> License "GPLv2" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
> If the software is closed-source, you may use "proprietary" as license.

So, this change should fix such issue. 

I'm not sure if this better `GPL-2.0-only` or `GPL-2.0-or-later` so take a look.
