### PR TITLE
Remove preg_replace e modifier from core

### DIFF
--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -877,7 +877,7 @@ function icms_html2text($document)
 			"'&(cent|#162);'i",
 			"'&(pound|#163);'i",
 			"'&(copy|#169);'i",
-			"'&#(\d+);'e");					// evaluate as php
+			);
 
 	$replace = array ("",
 			"",
@@ -892,9 +892,12 @@ function icms_html2text($document)
 			chr(162),
 			chr(163),
 			chr(169),
-			"chr(\\1)");
+			);
 
 	$text = preg_replace($search, $replace, $document);
+	$text = preg_replace_callback("'&#(\d+);'", function ($m) {
+		return chr($m[1]);
+	}, $text);
 	return $text;
 
 }

--- a/htdocs/libraries/icms/core/DataFilter.php
+++ b/htdocs/libraries/icms/core/DataFilter.php
@@ -745,9 +745,10 @@ class icms_core_DataFilter {
 	 */
 	static public function codePreConv($text, $imcode = 1) {
 		if ($imcode != 0) {
-			$patterns = "/\[code](.*)\[\/code\]/esU";
-			$replacements = "'[code]' . base64_encode('$1') . '[/code]'";
-			$text = preg_replace($patterns, $replacements, $text);
+			$patterns = "/\[code](.*)\[\/code\]/sU";
+			$text = preg_replace_callback($patterns, function ($match) {
+				return base64_encode($match[1]);
+			}, $text);
 		}
 		return $text;
 	}
@@ -762,17 +763,11 @@ class icms_core_DataFilter {
 	 */
 	static public function codeConv($text, $imcode = 1, $image = 1) {
 		if ($imcode != 0) {
-			$patterns = "/\[code](.*)\[\/code\]/esU";
-			if ($image != 0) {
-				$replacements = "'<div class=\"icmsCode\">' .
-					icms_core_DataFilter::textsanitizer_syntaxhighlight(icms_core_DataFilter::codeSanitizer('$1')) .
-					'</div>'";
-			} else {
-				$replacements = "'<div class=\"icmsCode\">' .
-					icms_core_DataFilter::textsanitizer_syntaxhighlight(icms_core_DataFilter::codeSanitizer('$1',0)) .
-					'</div>'";
-			}
-			$text = preg_replace($patterns, $replacements, $text);
+			$patterns = "/\[code](.*)\[\/code\]/sU";
+			$text = preg_replace_callback($patterns, function ($matches) use ($image) {
+				$code = icms_core_DataFilter::codeSanitizer($matches[1],($image != 0)?1:0);
+				return '<div class=\"icmsCode\">' . $code . '</div>';
+			}, $text);
 		}
 		return $text;
 	}

--- a/htdocs/plugins/textsanitizer/hashtags/hashtags.php
+++ b/htdocs/plugins/textsanitizer/hashtags/hashtags.php
@@ -18,9 +18,9 @@ define('HASHTAG_LINK',	ICMS_URL . '/search.php?query=%s&amp;action=results'); //
  * @return	str	String with the pattern replaced by a link
  */
 function textsanitizer_hashtags(&$ts, $text) {
-	$patterns[] = "#([\s\R])\#(?|([\w\-]+)|\[([\w\s\-]+)\])#e";
-	$replacements[] = "hashtag('\\2', '\\1')";
-	return preg_replace($patterns, $replacements, $text);
+	return preg_replace_callback("#([\s\R])\#(?|([\w\-]+)|\[([\w\s\-]+)\])#", function ($matches) {
+		return hashtag($matches[2], $matches[1]);
+	}, $text);
 }
 
 /**

--- a/htdocs/plugins/textsanitizer/mentions/mentions.php
+++ b/htdocs/plugins/textsanitizer/mentions/mentions.php
@@ -20,9 +20,9 @@ define('MENTIONS_LINK',	ICMS_URL . '/userinfo.php?uid=%u'); // The link to user 
  * @return	str	String with the pattern replaced by a link
  */
 function textsanitizer_mentions(&$ts, $text) {
-	$patterns[] = "#([\s\R])@(?|([\w\-]+)|\[([\w\s\-]+)\])#e";
-	$replacements[] = "mentions('\\2', '\\1')";
-	return preg_replace($patterns, $replacements, $text);
+	return preg_replace_callback("#([\s\R])@(?|([\w\-]+)|\[([\w\s\-]+)\])#", function ($matches) {
+		return mentions($matches[2], $matches[1]);
+	}, $text);
 }
 
 /**

--- a/htdocs/plugins/textsanitizer/syntaxhighlightcss/syntaxhighlightcss.php
+++ b/htdocs/plugins/textsanitizer/syntaxhighlightcss/syntaxhighlightcss.php
@@ -18,9 +18,9 @@
  * @param string $text the search terms
  */
 function textsanitizer_syntaxhighlightcss(&$ts, $text) {
-	$patterns[] = "/\[code_css](.*)\[\/code_css\]/esU";
-	$replacements[] = "textsanitizer_geshi_css_highlight( '\\1' )";
-	return preg_replace($patterns, $replacements, $text);
+	return preg_replace_callback("/\[code_css](.*)\[\/code_css\]/sU", function ($matches) {
+		return textsanitizer_geshi_css_highlight($matches[1]);
+	}, $text);
 }
 
 /**

--- a/htdocs/plugins/textsanitizer/syntaxhighlighthtml/syntaxhighlighthtml.php
+++ b/htdocs/plugins/textsanitizer/syntaxhighlighthtml/syntaxhighlighthtml.php
@@ -18,9 +18,9 @@
  * @param string $text the search terms
  */
 function textsanitizer_syntaxhighlighthtml(&$ts, $text) {
-	$patterns[] = "/\[code_html](.*)\[\/code_html\]/esU";
-	$replacements[] = "textsanitizer_geshi_html_highlight( '\\1' )";
-	return preg_replace($patterns, $replacements, $text);
+	return preg_replace_callback("/\[code_html](.*)\[\/code_html\]/sU", function ($matches) {
+		return textsanitizer_geshi_html_highlight($matches[1]);
+	}, $text);
 }
 
 /**

--- a/htdocs/plugins/textsanitizer/syntaxhighlightjs/syntaxhighlightjs.php
+++ b/htdocs/plugins/textsanitizer/syntaxhighlightjs/syntaxhighlightjs.php
@@ -18,9 +18,9 @@
  * @param string $text the search terms
  */
 function textsanitizer_syntaxhighlightjs(&$ts, $text) {
-	$patterns[] = "/\[code_js](.*)\[\/code_js\]/esU";
-	$replacements[] = "textsanitizer_geshi_js_highlight( '\\1' )";
-	return preg_replace($patterns, $replacements, $text);
+	return preg_replace_callback("/\[code_js](.*)\[\/code_js\]/sU", function ($matches) {
+		return textsanitizer_geshi_js_highlight($matches[1]);
+	}, $text);
 }
 
 /**

--- a/htdocs/plugins/textsanitizer/syntaxhighlightphp/syntaxhighlightphp.php
+++ b/htdocs/plugins/textsanitizer/syntaxhighlightphp/syntaxhighlightphp.php
@@ -18,9 +18,9 @@
  * @param string $text the search terms
  */
 function textsanitizer_syntaxhighlightphp(&$ts, $text) {
-	$patterns[] = "/\[code_php](.*)\[\/code_php\]/esU";
-	$replacements[] = "textsanitizer_geshi_php_highlight( '\\1' )";
-	return preg_replace($patterns, $replacements, $text);
+	return preg_replace_callback("/\[code_php](.*)\[\/code_php\]/sU", function ($matches) {
+		return textsanitizer_geshi_php_highlight($matches[1]);
+	}, $text);
 }
 
 /**

--- a/htdocs/plugins/textsanitizer/wiki/wiki.php
+++ b/htdocs/plugins/textsanitizer/wiki/wiki.php
@@ -23,9 +23,9 @@ define('WIKI_LINK',	'http://'._LANGCODE.'.wikipedia.org/wiki/%s');
  * @param unknown_type $text
  */
 function textsanitizer_wiki(&$ts, $text) {
-	$patterns[] = "/\[\[([^\]]*)\]\]/esU";
-	$replacements[] = "wikiLink( '\\1' )";
-	return preg_replace($patterns, $replacements, $text);
+	return preg_replace_callback("/\[\[([^\]]*)\]\]/sU", function ($matches) {
+		return wikiLink($matches[1]);
+	}, $text);
 }
 
 /**

--- a/htdocs/plugins/textsanitizer/youtube/youtube.php
+++ b/htdocs/plugins/textsanitizer/youtube/youtube.php
@@ -18,9 +18,9 @@
  * @param $text
  */
 function textsanitizer_youtube(&$ts, $text) {
-	$patterns[] = "/\[youtube=(['\"]?)([^\"']*),([^\"']*)\\1]([^\"]*)\[\/youtube\]/esU";
-	$replacements[] = "textsanitizer_youtube_decode( '\\4', '\\2', '\\3' )";
-	return preg_replace($patterns, $replacements, $text);
+	return preg_replace_callback("/\[youtube=(['\"]?)([^\"']*),([^\"']*)\\1]([^\"]*)\[\/youtube\]/sU", function ($matches) {
+		return textsanitizer_youtube_decode($matches[4], $matches[2], $matches[3]);
+	}, $text);
 }
 
 /**


### PR DESCRIPTION
e modifier was DEPRECATED in PHP 5.5.0, and REMOVED as of PHP 7.0.0. So, this pull requests fixes most of never PHP issues (f.e. all custom blocks on PHP 7.0 are rendered as empty without this fix).

One issue with this plugin is that it doesn't improve `icms_cleanTags` method. There are too much magic. But because it's market as needs to be removed, I think everything would be good enough.