### PR TITLE
Changed $_elements var access level in libraries/icms/form/Base.php

### DIFF
--- a/htdocs/libraries/icms/form/Base.php
+++ b/htdocs/libraries/icms/form/Base.php
@@ -73,7 +73,7 @@ abstract class icms_form_Base {
 	 * array of {@link icms_form_Element} objects
 	 * @var  array
 	 */
-	private $_elements = array();
+	protected $_elements = array();
 
 	/**
 	 * extra information for the <form> tag


### PR DESCRIPTION
Because we ipf base form inherits base xoops form, we have access level problem. $_elements field was set to private. So, this is fix for such issue.