### PR TITLE
Deprecated constructors for form elements fixes

### DIFF
--- a/htdocs/libraries/icms/form/elements/Editor.php
+++ b/htdocs/libraries/icms/form/elements/Editor.php
@@ -60,7 +60,7 @@ class icms_form_elements_Editor extends icms_form_elements_Textarea {
 	 * @param	bool  	$noHtml       use non-WYSIWYG eitor onfailure
 	 * @param	string  $OnFailure editor to be used if current one failed
 	 */
-	function icms_form_elements_Editor($caption, $name, $editor_configs = null, $noHtml=false, $OnFailure = "")
+	function __construct($caption, $name, $editor_configs = null, $noHtml=false, $OnFailure = "")
 	{
 		parent::__construct($caption, $editor_configs["name"]);
 		$editor_handler = icms_plugins_EditorHandler::getInstance();

--- a/htdocs/libraries/icms/form/elements/Hiddentoken.php
+++ b/htdocs/libraries/icms/form/elements/Hiddentoken.php
@@ -51,7 +51,7 @@ class icms_form_elements_Hiddentoken extends icms_form_elements_Hidden {
    * @param   string  $name       "name" attribute
    * @param   int     $timeout    timeout variable for the createToken function
    */
-  public function icms_form_elements_Hiddentoken($name = _CORE_TOKEN, $timeout = 0) {
+  public function __construct($name = _CORE_TOKEN, $timeout = 0) {
       parent::__construct($name . '_REQUEST', icms::$security->createToken($timeout, $name));
   }
 }


### PR DESCRIPTION
Some form elements has old constructors that will not work on never PHP versions. This pull request fixes. 