### PR TITLE
Fixed bug with $_uHandler var access level for ipf member class

### DIFF
--- a/htdocs/libraries/icms/member/Handler.php
+++ b/htdocs/libraries/icms/member/Handler.php
@@ -56,7 +56,7 @@ class icms_member_Handler {
 	/**
 	 * holds reference to user handler(DAO) class
 	 */
-	private $_uHandler;
+	protected $_uHandler;
 
 	/**
 	 * holds reference to membership handler(DAO) class
@@ -565,4 +565,3 @@ class icms_member_Handler {
 		return $ret;
 	}
 }
-


### PR DESCRIPTION
IPF member class is delivered from member class and that's why it has problem with private $_uHandler var. This small pull request should fix this issue.