### PR TITLE
Version checker uses GitHub for checking updates

### DIFF
--- a/htdocs/composer.json
+++ b/htdocs/composer.json
@@ -23,6 +23,7 @@
     "simplepie/simplepie": "1.3.1",
     "ezyang/htmlpurifier": "4.6.*",
     "tecnickcom/tcpdf": "6.*",
+	"kzykhys/ciconia": "^1.1",
     "ext-curl": "*",
     "ext-gd": "*",
     "ext-json": "*",

--- a/htdocs/composer.json
+++ b/htdocs/composer.json
@@ -23,7 +23,7 @@
     "simplepie/simplepie": "1.3.1",
     "ezyang/htmlpurifier": "4.6.*",
     "tecnickcom/tcpdf": "6.*",
-	"kzykhys/ciconia": "^1.1",
+	"erusev/parsedown": "^1.7.0",
     "ext-curl": "*",
     "ext-gd": "*",
     "ext-json": "*",

--- a/htdocs/libraries/icms/core/Versionchecker.php
+++ b/htdocs/libraries/icms/core/Versionchecker.php
@@ -106,7 +106,7 @@ class icms_core_Versionchecker {
 
 		if (version_compare(ICMS_VERSION, $data['tag_name'], '<')) {
 			// There is an update available
-			$this->latest_url = $data['url'];
+			$this->latest_url = $data['zipball_url'];
 			return true;
 		}
 		return false;

--- a/htdocs/libraries/icms/core/Versionchecker.php
+++ b/htdocs/libraries/icms/core/Versionchecker.php
@@ -5,9 +5,6 @@
 
 defined('ICMS_ROOT_PATH') or die("ImpressCMS root path not defined");
 
-use Ciconia\Ciconia;
-use Ciconia\Extension\Gfm;
-
 /**
  * IcmsVersionChecker
  *
@@ -141,13 +138,7 @@ class icms_core_Versionchecker {
 	 * @return string
 	 */
 	private function render($code) {
-		$ciconia = new Ciconia();
-		$ciconia->addExtension(new Gfm\FencedCodeBlockExtension());
-		$ciconia->addExtension(new Gfm\TaskListExtension());
-		$ciconia->addExtension(new Gfm\InlineStyleExtension());
-		$ciconia->addExtension(new Gfm\WhiteSpaceExtension());
-		$ciconia->addExtension(new Gfm\TableExtension());
-		$ciconia->addExtension(new Gfm\UrlAutoLinkExtension());
-		return $ciconia->render($code);
+		$p = new Parsedown();
+		return $p->text($code);
 	}
 }

--- a/htdocs/libraries/icms/core/Versionchecker.php
+++ b/htdocs/libraries/icms/core/Versionchecker.php
@@ -20,70 +20,35 @@ class icms_core_Versionchecker {
 
 	/**
 	 * Errors
-         *
+	 *
 	 * @var array
 	 */
 	public $errors = array();
 
 	/**
-	 * URL of the XML containing version information
-         *
-	 * @var string
-	 */
-	public $version_xml = "http://www.impresscms.org/impresscms_version_branch13.xml";
-
-	/**
-	 * Time before fetching the $version_xml again and store it in $cache_version_xml
-	 *
-         * @todo set this to a day at least or make it configurable in System Admin > Preferences
-         *
-         * @var integer
-	 */
-	public $cache_time=1;
-
-	/**
 	 * Name of the latest version
-         *
-         * @var string
+	 *
+	 * @var string
 	 */
 	public $latest_version_name = '';
 
 	/**
 	 * Name of installed version
-         *
+	 *
 	 * @var $installed_version_name string
 	 */
 	public $installed_version_name = ICMS_VERSION_NAME;
 
 	/**
-	 * Number of the latest build
-         *
-	 * @var integer
-	 */
-	public $latest_build = 0;
-
-	/**
-	 * Status of the latest build
-	 *
-	 * 1  = Alpha
-	 * 2  = Beta
-	 * 3  = RC
-	 * 10 = Final
-	 *
-	 * @var integer
-	 */
-	public $latest_status = 0;
-
-	/**
 	 * URL of the latest release
-         *
+	 *
 	 * @var string
 	 */
 	public $latest_url = '';
 
 	/**
 	 * Changelog of the latest release
-         *
+	 *
 	 * @var string
 	 */
 	public $latest_changelog = '';
@@ -111,40 +76,29 @@ class icms_core_Versionchecker {
 	 */
 	public function check() {
 
-		// Create a new instance of the SimplePie object
-		$feed = new icms_feeds_Simplerss();
-		$feed->set_feed_url($this->version_xml);
-		$feed->set_cache_duration(0);
-		$feed->set_autodiscovery_level(SIMPLEPIE_LOCATOR_NONE);
-		$feed->init();
-		$feed->handle_content_type();
-
-		if (!$feed->error) {
-			$versionInfo['title'] = $feed->get_title();
-			$versionInfo['link'] = $feed->get_link();
-			$versionInfo['image_url'] = $feed->get_image_url();
-			$versionInfo['image_title'] = $feed->get_image_title();
-			$versionInfo['image_link'] = $feed->get_image_link();
-			$feed_item = $feed->get_item(0);
-			$versionInfo['description'] = $feed_item->get_description();
-			$versionInfo['permalink'] = $feed_item->get_permalink();
-			$versionInfo['title'] = $feed_item->get_title();
-			$versionInfo['content'] = $feed_item->get_content();
-			$guidArray = $feed_item->get_item_tags('', 'guid');
-			$versionInfo['guid'] = $guidArray[0]['data'];
-		} else {
-			$this->errors[] = _AM_VERSION_CHECK_RSSDATA_EMPTY;
+		$ch = curl_init();
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
+		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+		curl_setopt($ch, CURLOPT_URL, 'https://api.github.com/repos/ImpressCMS/impresscms/releases/latest');
+		$result = curl_exec($ch);
+		if (!$result) {
+			$this->errors[] = curl_error($ch);
 			return false;
 		}
-		$this->latest_version_name = $versionInfo['title'];
-		$this->latest_changelog = $versionInfo['description'];
-		$build_info = explode('|', $versionInfo['guid']);
-		$this->latest_build = $build_info[0];
-		$this->latest_status = $build_info[1];
+		curl_close($ch);
 
-		if ($this->latest_build > ICMS_VERSION_BUILD) {
+		$data = json_decode($result, true);
+
+		$this->latest_version_name = $data['name'];
+		$this->latest_changelog = $data['body'];
+
+		if (substr($data['tag_name'], 0, 1) == 'v') {
+			$data['tag_name'] = substr($data['tag_name'], 1);
+		}
+
+		if (version_compare(ICMS_VERSION, $data['tag_name'])) {
 			// There is an update available
-			$this->latest_url = $versionInfo['link'];
+			$this->latest_url = $data['url'];
 			return true;
 		}
 		return false;
@@ -154,7 +108,7 @@ class icms_core_Versionchecker {
 	 * Gets all the error messages
 	 *
 	 * @param	$ashtml	bool	return as html?
-         *
+	 *
 	 * @return	mixed
 	 */
 	public function getErrors($ashtml=true) {

--- a/htdocs/modules/system/admin/version.php
+++ b/htdocs/modules/system/admin/version.php
@@ -40,10 +40,6 @@ if ($icmsVersionChecker->check()) {
 	$icmsAdminTpl->assign('latest_changelog', icms_core_DataFilter::makeClickable($icmsVersionChecker->latest_changelog));
 	$icmsAdminTpl->assign('latest_version', $icmsVersionChecker->latest_version_name);
 	$icmsAdminTpl->assign('latest_url', $icmsVersionChecker->latest_url);
-	if (ICMS_VERSION_STATUS == 10 && $icmsVersionChecker->latest_status < 10) {
-		// I'm running a final release so make sure to notify the user that the update is not a final
-		$icmsAdminTpl->assign('not_a_final_comment', TRUE);
-	}
 } else {
 	$checkerErrors = $icmsVersionChecker->getErrors(TRUE);
 	if ($checkerErrors) {

--- a/htdocs/modules/system/language/english/admin/version.php
+++ b/htdocs/modules/system/language/english/admin/version.php
@@ -10,10 +10,8 @@ define("_AM_VERSION_NO_UPDATE", 'You are running the latest version of ImpressCM
 define("_AM_VERSION_UPDATE_NEEDED", 'There is a new version of ImpressCMS ! The ImpressCMS Project strongly recommends always using the latest release.');
 define("_AM_VERSION_MOREINFO", 'Click on the following link to get more information on the latest release: ');
 
-define("_AM_VERSION_CHECK_RSSDATA_EMPTY", 'No information was available to check for an updated release.');
 define("_AM_VERSION_CHANGELOG", 'Changelog');
 define("_AM_VERSION_WARNING", 'Warning');
-define("_AM_VERSION_WARNING_NOT_A_FINAL", 'Please note that you are currently running a "Final" version of ImpressCMS and the proposed updated release is not a "Final" release. All releases other then "Final" should not be used on a production environment. If your install of ImpressCMS is running on a production environment, we recommend you wait for a final release. More info can be found: <a href="http://wiki.impresscms.org/index.php?title=Final_release">here</a>.');
 
 define("_AM_VERSION_YOUR_VERSION", 'Your ImpressCMS Version:');
 define("_AM_VERSION_LATEST_VERSION", 'Latest ImpressCMS Version:');

--- a/htdocs/modules/system/templates/admin/system_adm_version.html
+++ b/htdocs/modules/system/templates/admin/system_adm_version.html
@@ -11,9 +11,6 @@
 	        <br />
 	        <{$smarty.const._AM_VERSION_MOREINFO}><br />
 	        <h2><a href="<{$latest_url}>" rel="external"><{$latest_version}></a></h2>
-		<{if $not_a_final_comment}> 	 
-			<div><strong><{$smarty.const._AM_VERSION_WARNING}></strong>: <{$smarty.const._AM_VERSION_WARNING_NOT_A_FINAL}></div> 	 
-		<{/if}>
 	    </div>
     </div>
 
@@ -27,7 +24,7 @@
 			<div class="errorMsg">
 				<{$errors}>
 			</div>
-		<{else}>    
+		<{else}>
         	<div class="successMsg"><strong><{$smarty.const._AM_VERSION_NO_UPDATE}></strong></div>
         <{/if}>
     </div>

--- a/htdocs/themes/core/modules/system/admin/system_adm_version.html
+++ b/htdocs/themes/core/modules/system/admin/system_adm_version.html
@@ -8,12 +8,9 @@
     <div class="even">
 	    <div class="alert alert-warning" role="alert">
 	        <strong><{$smarty.const._AM_VERSION_UPDATE_NEEDED}></strong>
-	       
+
 	        <{$smarty.const._AM_VERSION_MOREINFO}>
 	        <h2><a href="<{$latest_url}>" rel="external"><{$latest_version}></a></h2>
-		<{if $not_a_final_comment}> 	 
-			<div  class="alert alert-warning" role="alert"><strong><{$smarty.const._AM_VERSION_WARNING}></strong>: <{$smarty.const._AM_VERSION_WARNING_NOT_A_FINAL}></div> 	 
-		<{/if}>
 	    </div>
     </div>
 
@@ -27,7 +24,7 @@
 			<div class="alert alert-danger" role="alert">
 				<{$errors}>
 			</div>
-		<{else}>    
+		<{else}>
         	<div class="alert alert-success" role="alert"><strong><{$smarty.const._AM_VERSION_NO_UPDATE}></strong></div>
         <{/if}>
     </div>

--- a/tests/libraries/icms/VersionCheckerTest.php
+++ b/tests/libraries/icms/VersionCheckerTest.php
@@ -40,11 +40,8 @@ class VersionCheckerTest extends \PHPUnit_Framework_TestCase {
     public function testVariables() {
         $instance = \icms_core_Versionchecker::getInstance();
         $this->assertInternalType('array', $instance->errors, '$errors must be array');
-        $this->assertInternalType('string', $instance->version_xml, '$version_xml must be string');
         $this->assertInternalType('string', $instance->latest_version_name, '$latest_version_name must be string');
         $this->assertInternalType('string', $instance->installed_version_name, '$installed_version_name must be string');
-        $this->assertInternalType('int', $instance->latest_build, '$latest_build must be int');
-        $this->assertInternalType('int', $instance->latest_status, '$latest_status must be int');
         $this->assertInternalType('string', $instance->latest_url, '$latest_url must be string');
         $this->assertInternalType('string', $instance->latest_changelog, '$latest_changelog must be string');
     }


### PR DESCRIPTION
We can get latest version info from GitHub so why not to use this data when checking for updates? This pull requests does that!

One possible issue with this change is that it doesn't checks for anything on GitHub that is not a final release but I think maybe that is not a bad thing.