### PR TITLE
Remove var-dump from autotask preload (1.3.11)

### DIFF
--- a/htdocs/plugins/preloads/autotasks.php
+++ b/htdocs/plugins/preloads/autotasks.php
@@ -26,7 +26,6 @@ class IcmsPreloadAutotasks extends icms_preload_Item {
 			$rez = $handler->execTasks();
 			$handler->startIfNeeded();
 			if ($handler->needExit()) {
-				var_dump($rez);
 				exit(0);
 			}
 		}

--- a/htdocs/plugins/preloads/autotasks.php
+++ b/htdocs/plugins/preloads/autotasks.php
@@ -23,7 +23,7 @@ class IcmsPreloadAutotasks extends icms_preload_Item {
 	function eventFinishCoreBoot() {
 		$handler = &icms_getModuleHandler('autotasks', 'system');
 		if ($handler->needExecution()) {
-			$rez = $handler->execTasks();
+			$handler->execTasks();
 			$handler->startIfNeeded();
 			if ($handler->needExit()) {
 				exit(0);


### PR DESCRIPTION
Same as #217 but for 1.3.11