### PR TITLE
Fixed class name for SessionTest.php

### DIFF
--- a/tests/libraries/icms/SessionTest.php
+++ b/tests/libraries/icms/SessionTest.php
@@ -7,7 +7,7 @@ namespace ImpressCMS\Tests\Libraries\ICMS;
 * @backupStaticAttributes disabled
 */
 
-class SecurityTest extends \PHPUnit_Framework_TestCase {
+class SessionTest extends \PHPUnit_Framework_TestCase {
 
     /**
      * Test if icms_core_DataFilter is available


### PR DESCRIPTION
Previously SessionTest.php had class SecurityTest but same class existed also in SecurityTest.php, so this pull request should fix such issue.