### PR TITLE
Fixed mistyped comment in impresscms/htdocs/modules/system/language/e…

### DIFF
--- a/htdocs/modules/system/language/english/modinfo.php
+++ b/htdocs/modules/system/language/english/modinfo.php
@@ -30,7 +30,6 @@ define('_MI_SYSTEM_BNAME14', "Language Selection");
 define('_MI_SYSTEM_BNAME15', "Content");
 define('_MI_SYSTEM_BNAME16', "Content Menu");
 define('_MI_SYSTEM_BNAME17', "Related Content");
-/*/
 
 define('_MI_SYSTEM_BNAME18', "Share this page!");
 


### PR DESCRIPTION
…nglish/modinfo.php

I think when I removed `@version` tags in comments accidentally made such mistake. So, here is the fix. 