### PR TITLE
Remove CSSTidy vulnerability warning

### DIFF
--- a/modules/system/blocks/system_admin_blocks.php
+++ b/modules/system/blocks/system_admin_blocks.php
@@ -42,10 +42,6 @@ function b_system_admin_warnings_show() {
 		array_push($block['msg'], icms_core_Message::error(sprintf(_WARNINSTALL2, ICMS_ROOT_PATH . '/upgrade/'), '', FALSE));
 	}
 
-	if (file_exists(ICMS_PLUGINS_PATH . '/csstidy/css_optimiser.php')) {
-		array_push($block['msg'], icms_core_Message::error(sprintf(_CSSTIDY_VULN, ICMS_PLUGINS_PATH . '/csstidy/css_optimiser.php'), FALSE));
-	}
-
 	// ###### Output warn messages for correct functionality  ######
 	if (!is_writable(ICMS_CACHE_PATH))
 		array_push($block['msg'], icms_core_Message::warning(sprintf(_WARNINNOTWRITEABLE, ICMS_CACHE_PATH)), '', FALSE);


### PR DESCRIPTION
CSSTidy is loaded with composer so we don't need such warning (such detection it will not work)