### PR TITLE
Coding style improvement: `$obj->getVar('x', 'n')` -> `$obj->x`

### DIFF
--- a/htdocs/install/modulesadmin.php
+++ b/htdocs/install/modulesadmin.php
@@ -712,13 +712,13 @@ function icms_module_update($dirname) {
 			$msgs[] = 'Deleting module config options...';
 			for ($i = 0; $i < $confcount; $i++) {
 				if (!$config_handler->deleteConfig($configs[$i])) {
-					$msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">ERROR: Could not delete config data from the database. Config ID: <b>'.$configs[$i]->getvar('conf_id').'</b></span>';
+					$msgs[] = '&nbsp;&nbsp;<span style="color:#ff0000;">ERROR: Could not delete config data from the database. Config ID: <b>' . $configs[$i]->getVar('conf_id') . '</b></span>';
 					// save the name of config failed to delete for later use
-					$config_delng[] = $configs[$i]->getvar('conf_name');
+					$config_delng[] = $configs[$i]->getVar('conf_name');
 				} else {
-					$config_old[$configs[$i]->getvar('conf_name')]['value'] = $configs[$i]->getvar('conf_value', 'N');
-					$config_old[$configs[$i]->getvar('conf_name')]['formtype'] = $configs[$i]->getvar('conf_formtype');
-					$config_old[$configs[$i]->getvar('conf_name')]['valuetype'] = $configs[$i]->getvar('conf_valuetype');
+					$config_old[$configs[$i]->getVar('conf_name')]['value'] = $configs[$i]->conf_value;
+					$config_old[$configs[$i]->getVar('conf_name')]['formtype'] = $configs[$i]->getVar('conf_formtype');
+					$config_old[$configs[$i]->getVar('conf_name')]['valuetype'] = $configs[$i]->getVar('conf_valuetype');
 					$msgs[] = '&nbsp;&nbsp;Config data deleted from the database. Config ID: <b>'.$configs[$i]->getVar('conf_id').'</b>';
 				}
 			}

--- a/include/functions.php
+++ b/include/functions.php
@@ -2166,7 +2166,7 @@ function icms_moduleAction($dirname = 'system')
 	global $icmsModule;
 	$ret = @(
 			// action module 'system'
-			!empty($icmsModule) && 'system' == $icmsModule->getVar('dirname', 'n')
+		!empty($icmsModule) && 'system' == $icmsModule->dirname
 			&&
 			// current dirname
 			($dirname == $_POST['dirname'] || $dirname == $_POST['module'])

--- a/libraries/icms/config/item/Object.php
+++ b/libraries/icms/config/item/Object.php
@@ -118,18 +118,18 @@ class icms_config_item_Object extends icms_ipf_Object {
 	public function getConfValueForOutput() {
 		switch($this->getVar('conf_valuetype')) {
 			case 'int':
-				return (int) ($this->getVar('conf_value', 'N'));
+				return (int)($this->conf_value);
 				break;
 
 			case 'array':
-                $value = $this->getVar('conf_value', 'N');
+				$value = $this->conf_value;
                 if ($value === null || strlen($value) < 2 || (substr($value, 1, 1) != ':'))
                 	return array();
                 $value = @unserialize($value);
 				return $value ? $value : array();
 
 			case 'float':
-				$value = $this->getVar('conf_value', 'N');
+				$value = $this->conf_value;
 				return (float) $value;
 				break;
 
@@ -140,7 +140,7 @@ class icms_config_item_Object extends icms_ipf_Object {
 			case 'textarea':
 				return icms_core_DataFilter::checkVar($this->getVar('conf_value'), 'html', 'output');
 			default:
-				return $this->getVar('conf_value', 'N');
+				return $this->conf_value;
 				break;
 		}
 	}

--- a/libraries/icms/member/user/Object.php
+++ b/libraries/icms/member/user/Object.php
@@ -348,7 +348,7 @@ class icms_member_user_Object extends icms_ipf_Object {
     public function isAdmin($module_id = null) {
         static $buffer = array();
         if (is_null($module_id)) {
-            $module_id = isset($GLOBALS['xoopsModule']) ? $GLOBALS['xoopsModule']->getVar('mid', 'n') : 1;
+			$module_id = isset($GLOBALS['xoopsModule']) ? $GLOBALS['xoopsModule']->mid : 1;
         } elseif ((int) $module_id < 1) {
             $module_id = 0;
         }

--- a/libraries/icms/view/PageBuilder.php
+++ b/libraries/icms/view/PageBuilder.php
@@ -119,7 +119,7 @@ class icms_view_PageBuilder {
 		$tplfile_handler = icms::handler('icms_view_template_file');
 		$tplfile_handler->prefetchBlocks($block_arr);
 		foreach ($block_arr as $block) {
-			$side = $oldzones[$block->getVar('side', 'n')];
+			$side = $oldzones[$block->side];
 			if ($var = $this->buildBlock($block, $template)) {
 				$this->blocks[$side][$var["id"]] = $var;
 			}
@@ -272,7 +272,7 @@ class icms_view_PageBuilder {
 		}
 		$tplName = ($tplName = $xobject->getVar('template')) ? "db:$tplName" : "db:system_block_dummy.html";
 		$cacheid = $this->generateCacheId(
-			'blk_' . $xobject->getVar('dirname', 'n') . '_'
+			'blk_' . $xobject->dirname . '_'
 			. $bid
 		);
 

--- a/libraries/icms/view/Tpl.php
+++ b/libraries/icms/view/Tpl.php
@@ -169,7 +169,7 @@ class icms_view_Tpl extends Smarty {
 		$tplfile =& $tplfile_handler->get($tpl_id);
 
 		if (is_object($tplfile)) {
-			$file = $tplfile->getVar('tpl_file', 'n');
+			$file = $tplfile->tpl_file;
 			$tpl = new icms_view_Tpl();
 			return $tpl->touch("db:$file");
 		}

--- a/libraries/icms/view/block/Object.php
+++ b/libraries/icms/view/block/Object.php
@@ -154,7 +154,7 @@ class icms_view_block_Object extends icms_ipf_Object {
 		switch ($format) {
 			case 'S':
 				if ($c_type == 'H') {
-                    $content = $this->getVar('content', 'n');
+					$content = $this->content;
                     $content = str_replace('{X_SITEURL}', ICMS_URL . '/', $content);
                     $content = str_replace(getenv('DB_SALT'), '', $content);
 					return $content;
@@ -168,10 +168,10 @@ class icms_view_block_Object extends icms_ipf_Object {
 					return $content;
 				} elseif ($c_type == 'S') {
 					$myts = icms_core_Textsanitizer::getInstance();
-					$content = str_replace('{X_SITEURL}', ICMS_URL . '/', $this->getVar('content', 'n'));
+					$content = str_replace('{X_SITEURL}', ICMS_URL . '/', $this->content);
 					return $myts->displayTarea($content, 1, 1);
 				} else {
-					$content = str_replace('{X_SITEURL}', ICMS_URL . '/', $this->getVar('content', 'n'));
+					$content = str_replace('{X_SITEURL}', ICMS_URL . '/', $this->content);
 					return icms_core_DataFilter::checkVar($content, 'text', 'output');
 				}
 				break;
@@ -181,7 +181,7 @@ class icms_view_block_Object extends icms_ipf_Object {
 				break;
 
 			default:
-				return $this->getVar('content', 'n');
+				return $this->content;
 				break;
 		}
 	}

--- a/libraries/icms/view/theme/Object.php
+++ b/libraries/icms/view/theme/Object.php
@@ -297,7 +297,7 @@ class icms_view_theme_Object {
 
 		if ($_SERVER['REQUEST_METHOD'] != 'POST' && $this->contentCacheLifetime) {
 			$template = $this->contentTemplate ? $this->contentTemplate : 'db:system_dummy.html';
-			$dirname = $icmsModule->getVar('dirname', 'n');
+			$dirname = $icmsModule->dirname;
 
 			$this->template->caching = 2;
 			$this->template->cache_lifetime = $this->contentCacheLifetime;
@@ -368,7 +368,7 @@ class icms_view_theme_Object {
 		$header = empty($xoopsOption['icms_module_header'])
 			? $this->template->get_template_vars('icms_module_header')
 			: $xoopsOption['icms_module_header'];
-		
+
 		$this->template->assign('icms_module_header', $header . "\n" . $this->renderOldMetas(NULL, TRUE));
 
 		/* create template vars for the new meta zones */
@@ -379,7 +379,7 @@ class icms_view_theme_Object {
 		$pagetitle = empty($xoopsOption['icms_pagetitle'])
 			? $this->template->get_template_vars('icms_pagetitle')
 			: $xoopsOption['icms_pagetitle'];
-	
+
 		$this->template->assign('icms_pagetitle', $pagetitle);
 
 		// Do not cache the main (theme.html) template output

--- a/modules/system/admin/modules/modules.php
+++ b/modules/system/admin/modules/modules.php
@@ -853,7 +853,7 @@ function xoops_module_uninstall($dirname) {
 					for ($i = 0; $i < $confcount; $i++) {
 						if (!$config_handler->deleteConfig($configs[$i])) {
 							$msgs[] = sprintf('&nbsp;&nbsp;<span style="color:#ff0000;">' . _MD_AM_CONFIGOPTION_DELETE_FAIL .'</span>',
-								'<strong>' . icms_conv_nr2local($configs[$i]->getvar('conf_id')) . '</strong>');
+								'<strong>' . icms_conv_nr2local($configs[$i]->getVar('conf_id')) . '</strong>');
 						} else {
 							$msgs[] = sprintf('&nbsp;&nbsp;' . _MD_AM_CONFIGOPTION_DELETED,
 								'<strong>' . icms_conv_nr2local($configs[$i]->getVar('conf_id')) . '</strong>');
@@ -1321,13 +1321,13 @@ function icms_module_update($dirname) {
 			for ($i = 0; $i < $confcount; $i++) {
 				if (!$config_handler->deleteConfig($configs[$i])) {
 					$msgs[] = sprintf('&nbsp;&nbsp;<span style="color:#ff0000;">' . _MD_AM_CONFIGOPTION_DELETE_FAIL . '</span>',
-						'<strong>' . $configs[$i]->getvar('conf_id') . '</strong>');
+						'<strong>' . $configs[$i]->getVar('conf_id') . '</strong>');
 					// save the name of config failed to delete for later use
-					$config_delng[] = $configs[$i]->getvar('conf_name');
+					$config_delng[] = $configs[$i]->getVar('conf_name');
 				} else {
-					$config_old[$configs[$i]->getvar('conf_name')]['value'] = $configs[$i]->getvar('conf_value', 'N');
-					$config_old[$configs[$i]->getvar('conf_name')]['formtype'] = $configs[$i]->getvar('conf_formtype');
-					$config_old[$configs[$i]->getvar('conf_name')]['valuetype'] = $configs[$i]->getvar('conf_valuetype');
+					$config_old[$configs[$i]->getVar('conf_name')]['value'] = $configs[$i]->conf_value;
+					$config_old[$configs[$i]->getVar('conf_name')]['formtype'] = $configs[$i]->getVar('conf_formtype');
+					$config_old[$configs[$i]->getVar('conf_name')]['valuetype'] = $configs[$i]->getVar('conf_valuetype');
 					$msgs[] = sprintf('&nbsp;&nbsp;' . _MD_AM_CONFIGOPTION_DELETED,
 						'<strong>' . $configs[$i]->getVar('conf_id') . '</strong>');
 				}

--- a/modules/system/class/Adsense.php
+++ b/modules/system/class/Adsense.php
@@ -125,25 +125,25 @@ class mod_system_Adsense extends icms_ipf_Object {
 	 * @return	string
 	 */
 	public function render() {
-		if ($this->getVar('style', 'n') != '') {
-			$ret = '<div style="' . $this->getVar('style', 'n') . '">';
+		if ($this->style != '') {
+			$ret = '<div style="' . $this->style . '">';
 		} else {
 			$ret = '<div>';
 		}
 
 		$ret .= '<script type="text/javascript">'
-			. 'google_ad_client = "' . $this->getVar('client_id', 'n') . '";'
+			. 'google_ad_client = "' . $this->client_id . '";'
 			. 'google_ad_slot = "' . $this->getVar("slot", "n") . '";'
-			. 'google_ad_width = ' . $this->handler->adFormats[$this->getVar('format', 'n')]['width'] . ';'
-			. 'google_ad_height = ' . $this->handler->adFormats[$this->getVar('format', 'n')]['height'] . ';'
-			. 'google_ad_format = "' . $this->getVar('format', 'n') . '";'
+			. 'google_ad_width = ' . $this->handler->adFormats[$this->format]['width'] . ';'
+			. 'google_ad_height = ' . $this->handler->adFormats[$this->format]['height'] . ';'
+			. 'google_ad_format = "' . $this->format . '";'
 			. 'google_ad_type = "text";'
 			. 'google_ad_channel ="";'
-			. 'google_color_border = "' . $this->getVar('color_border', 'n') . '";'
-			. 'google_color_bg = "' . $this->getVar('color_background', 'n') . '";'
-			. 'google_color_link = "' . $this->getVar('color_link', 'n') . '";'
-			. 'google_color_url = "' . $this->getVar('color_url', 'n') . '";'
-			. 'google_color_text = "' . $this->getVar('color_text', 'n') . '";'
+			. 'google_color_border = "' . $this->color_border . '";'
+			. 'google_color_bg = "' . $this->color_background . '";'
+			. 'google_color_link = "' . $this->color_link . '";'
+			. 'google_color_url = "' . $this->color_url . '";'
+			. 'google_color_text = "' . $this->color_text . '";'
 			. '</script>'
 			. '<script type="text/javascript" src="http://pagead2.googlesyndication.com/pagead/show_ads.js">'
 			. '</script>'
@@ -157,7 +157,7 @@ class mod_system_Adsense extends icms_ipf_Object {
 	 * @return	string
 	 */
 	public function getXoopsCode() {
-		$ret = '[adsense]' . $this->getVar('tag', 'n') . '[/adsense]';
+		$ret = '[adsense]' . $this->tag . '[/adsense]';
 		return $ret;
 	}
 

--- a/modules/system/class/Blocks.php
+++ b/modules/system/class/Blocks.php
@@ -79,7 +79,7 @@ class mod_system_Blocks extends icms_view_block_Object {
 	 * Custom accesser for weight property
 	 */
 	private function weight() {
-		$rtn = $this->getVar('weight', 'n');
+		$rtn = $this->weight;
 		return $rtn;
 	}
 
@@ -87,7 +87,7 @@ class mod_system_Blocks extends icms_view_block_Object {
 	 * Custom accessor for visible property
 	 */
 	private function visible() {
-		if ($this->getVar('visible', 'n') == 1) {
+		if ($this->visible == 1) {
 			$rtn = '<a href="' . ICMS_MODULES_URL . '/system/admin.php?fct=blocks&op=visible&bid='
 				. $this->getVar('bid') . '" title="' . _VISIBLE . '" ><img src="' . ICMS_IMAGES_SET_URL
 				. '/actions/button_ok.png" alt="' . _VISIBLE . '"/></a>';
@@ -102,7 +102,7 @@ class mod_system_Blocks extends icms_view_block_Object {
 	 * Custom accessor for mid property
 	 */
 	private function mid() {
-		$rtn = $this->handler->getModuleName($this->getVar('mid', 'n'));
+		$rtn = $this->handler->getModuleName($this->mid);
 		return $rtn;
 	}
 
@@ -111,9 +111,9 @@ class mod_system_Blocks extends icms_view_block_Object {
 	 */
 	private function side() {
 		$block_positions = $this->handler->getBlockPositions(TRUE);
-		$rtn = (defined($block_positions[$this->getVar('side', 'n')]['title']))
-			? constant($block_positions[$this->getVar('side', 'n')]['title'])
-			: $block_positions[$this->getVar('side', 'n')]['title'];
+		$rtn = (defined($block_positions[$this->side]['title']))
+			? constant($block_positions[$this->side]['title'])
+			: $block_positions[$this->side]['title'];
 		return $rtn;
 	}
 

--- a/modules/system/class/BlocksHandler.php
+++ b/modules/system/class/BlocksHandler.php
@@ -132,7 +132,7 @@ class mod_system_BlocksHandler extends icms_view_block_Handler {
 
 	public function changeVisible($bid) {
 		$blockObj = $this->get($bid);
-		if ($blockObj->getVar('visible' , 'n')) {
+		if ($blockObj->visible) {
 			$blockObj->setVar('visible', 0);
 		} else {
 			$blockObj->setVar('visible', 1);

--- a/modules/system/class/Customtag.php
+++ b/modules/system/class/Customtag.php
@@ -77,12 +77,12 @@ class mod_system_Customtag extends icms_ipf_Object {
 		if (!$this->content) {
 			switch ($this->getVar('customtag_type')) {
 				case ICMS_CUSTOMTAG_TYPE_XCODES:
-					$ret = $this->getVar('customtag_content', 'N');
+					$ret = $this->customtag_content;
 					$ret = $myts->displayTarea($ret, 1, 1, 1, 1, 1);
 					break;
 
 				case ICMS_CUSTOMTAG_TYPE_HTML:
-					$ret = $this->getVar('customtag_content', 'N');
+					$ret = $this->customtag_content;
 					$ret = $myts->displayTarea($ret, 1, 1, 1, 1, 0);
 					break;
 
@@ -103,7 +103,7 @@ class mod_system_Customtag extends icms_ipf_Object {
 	 */
 	public function renderWithPhp() {
 		if (!$this->content && !$this->evaluated) {
-			$ret = $this->getVar('customtag_content', 'N');
+			$ret = $this->customtag_content;
 
 			// check for PHP if we are not on admin side
 			if (!defined('XOOPS_CPFUNC_LOADED' ) && $this->getVar('customtag_type') == ICMS_CUSTOMTAG_TYPE_PHP) {
@@ -124,7 +124,7 @@ class mod_system_Customtag extends icms_ipf_Object {
 	 * Generate a bbcode for the custom tag
 	 */
 	public function getXoopsCode() {
-		$ret = '[customtag]' . $this->getVar('name', 'n') . '[/customtag]';
+		$ret = '[customtag]' . $this->name . '[/customtag]';
 		return $ret;
 	}
 

--- a/modules/system/class/Rating.php
+++ b/modules/system/class/Rating.php
@@ -10,9 +10,9 @@
 
 /**
  * Rating object
- * 
+ *
  * @package     ImpressCMS\Modules\System\Class\Rating
- * 
+ *
  * @property int    $ratingid   Rating ID
  * @property string $dirname    Module dirname
  * @property string $item       Item type
@@ -20,7 +20,7 @@
  * @property int    $uid        User ID
  * @property int    $date       Date
  * @property int    $rate       Rate
- * 
+ *
  * @property string $name       Name
  */
 class mod_system_Rating extends icms_ipf_Object {
@@ -46,7 +46,7 @@ class mod_system_Rating extends icms_ipf_Object {
 		$this->setControl('item', array('object' => &$this, 'method' => 'getItemList'));
 		$this->setControl('uid', 'user');
 		$this->setControl('rate', array('method' => 'getRateList'));
-                
+
                 parent::__construct($handler);
 	}
 
@@ -78,7 +78,7 @@ class mod_system_Rating extends icms_ipf_Object {
 	 */
 	public function dirname() {
 		$moduleArray = $this->handler->getModuleList();
-		return $moduleArray[$this->getVar('dirname', 'n')];
+		return $moduleArray[$this->dirname];
 	}
 
 	/**
@@ -95,7 +95,7 @@ class mod_system_Rating extends icms_ipf_Object {
 	 * @return	string
 	 */
 	public function getItemValue() {
-		$moduleUrl = ICMS_MODULES_URL . '/' . $this->getVar('dirname', 'n') . '/';
+		$moduleUrl = ICMS_MODULES_URL . '/' . $this->dirname . '/';
 		$plugin = $this->getModulePlugin();
 		$pluginItemInfo = $plugin->getItemInfo($this->getVar('item'));
 		if (!$pluginItemInfo) {
@@ -129,7 +129,7 @@ class mod_system_Rating extends icms_ipf_Object {
 	 */
 	public function getModulePlugin() {
 		if (!$this->_modulePlugin) {
-			$this->_modulePlugin = $this->handler->pluginsObject->getPlugin('rating', $this->getVar('dirname', 'n'));
+			$this->_modulePlugin = $this->handler->pluginsObject->getPlugin('rating', $this->dirname);
 		}
 		return $this->_modulePlugin;
 	}

--- a/readpmsg.php
+++ b/readpmsg.php
@@ -125,7 +125,7 @@ if (is_object($poster) == TRUE) { // no need to do this for deleted users
 	$icmsTpl->assign('anonymous', $icmsConfig['anonymous']);
 }
 
-$var = $pm_arr[0]->getVar('msg_text', 'N');
+$var = $pm_arr[0]->msg_text;
 
 // see if the sender had permission to use wysiwyg for the system module - in 2.0, everyone will
 /* @todo remove editor permission check in 2.0 */

--- a/userinfo.php
+++ b/userinfo.php
@@ -141,7 +141,7 @@ icms_makeSmarty(array(
 	'lang_interest' => _US_INTEREST,
 	'user_interest' => $thisUser->getVar('user_intrest'),
 	'lang_extrainfo' => _US_EXTRAINFO,
-	'user_extrainfo' => icms_core_DataFilter::checkVar($thisUser->getVar('bio', 'N'), 'text', 'output'),
+	'user_extrainfo' => icms_core_DataFilter::checkVar($thisUser->bio, 'text', 'output'),
 	'lang_statistics' => _US_STATISTICS,
 	'lang_membersince' => _US_MEMBERSINCE,
 	'user_joindate' => formatTimestamp($thisUser->getVar('user_regdate'), 's'),
@@ -177,11 +177,11 @@ icms_makeSmarty(array(
 		: '&nbsp;'
 ));
 
-if ($icmsConfigUser['allwshow_sig'] == TRUE && strlen(trim($thisUser->getVar('user_sig', 'N'))) > 0) {
+if ($icmsConfigUser['allwshow_sig'] == TRUE && strlen(trim($thisUser->user_sig)) > 0) {
    	icms_makeSmarty(array(
 		'user_showsignature' => TRUE,
 		'lang_signature' => _US_SIGNATURE,
-		'user_signature' => icms_core_DataFilter::checkVar($thisUser->getVar('user_sig', 'N'), 'html', 'output')
+		'user_signature' => icms_core_DataFilter::checkVar($thisUser->user_sig, 'html', 'output')
 	));
 }
 


### PR DESCRIPTION
Because with new properties system is possible write `$obj->x` instead of `$obj->getVar('x', 'n')`, this pull request uses this new feature and a bit improved code syntax style.