### PR TITLE
Same ident style for all json, yml and yaml files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,5 @@
-# top-most EditorConfig file
 root = true
 
-# Unix-style newlines with a newline ending every file
 [*]
 end_of_line = lf
 insert_final_newline = false
@@ -10,6 +8,6 @@ indent_style = tab
 trim_trailing_whitespace = true
 tab_width = 4
 
-[{package.json,.travis.yml}]
+[*.{json,yml,yaml}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
This should make use same spaces length in all json, yml and yaml files not only `package.json` and `.travis.yml`, because we right now have a bit more files with such extensions.