### PR TITLE
`template_touch` and `template_clear_module_cache` now is everywhere called as static methods. 

### DIFF
--- a/htdocs/install/modulesadmin.php
+++ b/htdocs/install/modulesadmin.php
@@ -479,7 +479,8 @@ function icms_module_update($dirname) {
 	// Save current version for use in the update function
 	$prev_version = $module->getVar('version');
 	$prev_dbversion = $module->getVar('dbversion');
-	xoops_template_clear_module_cache($module->getVar('mid'));
+	icms_view_Tpl::template_clear_module_cache($module->getVar('mid'));
+
 	// we dont want to change the module name set by admin
 	$temp_name = $module->getVar('name');
 	$module->loadInfoAsVar($dirname);

--- a/libraries/icms/view/Tpl.php
+++ b/libraries/icms/view/Tpl.php
@@ -172,17 +172,7 @@ class icms_view_Tpl extends Smarty {
 	/**
 	 * Clear the module cache
 	 *
-	 * Prior to PHP5.3.0, when refering to the class with a variable, like $icmsAdminTpl, you
-	 * still need to use the arrow operator instead of ::
-	 * http://www.php.net/manual/en/language.oop5.paamayim-nekudotayim.php
-	 *
-	 * The proper way to use this would be
-	 * icms_view_Tpl::template_clear_module_cache($tplid);
-	 * or
-	 * $icmsAdminTpl->template_clear_module_cache($tplid);
-	 *
 	 * @param   int $mid    Module ID
-	 * @return
 	 */
 	static public function template_clear_module_cache($mid) {
 		$icms_block_handler = icms::handler('icms_view_block');

--- a/libraries/icms/view/Tpl.php
+++ b/libraries/icms/view/Tpl.php
@@ -151,17 +151,10 @@ class icms_view_Tpl extends Smarty {
 	}
 
 	/**
-	 * function to update compiled template file in cached templates folder
-	 * Prior to PHP5.3.0, when refering to the class with a variable, like $icmsAdminTpl, you
-	 * still need to use the arrow operator instead of ::
-	 * http://www.php.net/manual/en/language.oop5.paamayim-nekudotayim.php
-	 *
-	 * The proper way to use this would be
-	 * icms_view_Tpl::template_touch($tplid);
-	 * or
-	 * $icmsAdminTpl->template_touch($tplid);
+	 * Touch template by id
 	 *
 	 * @param   string  $tpl_id
+	 *
 	 * @return  boolean
 	 */
 	static public function template_touch($tpl_id) {

--- a/modules/system/admin/modules/modules.php
+++ b/modules/system/admin/modules/modules.php
@@ -262,7 +262,7 @@ function xoops_module_install($dirname) {
 								'<strong>' . $tpl['file'] . '</strong>', '<strong>' . $newtplid . '</strong>');
 
 							// generate compiled file
-							if (!$icmsAdminTpl->template_touch($newtplid)) {
+							if (!icms_view_Tpl::template_touch($newtplid)) {
 								$msgs[] = sprintf('&nbsp;&nbsp;<span style="color:#ff0000;">' . _MD_AM_TEMPLATE_COMPILE_FAIL . '</span>',
 									'<strong>' . $tpl['file'] . '</strong>', '<strong>' . $newtplid . '</strong>');
 							} else {
@@ -332,7 +332,7 @@ function xoops_module_install($dirname) {
 									$msgs[] = sprintf(_MD_AM_TEMPLATE_INSERTED, '<strong>' . $block['template'] . '</strong>',
 										'<strong>' . icms_conv_nr2local($newtplid) . '</strong>');
 									// generate compiled file
-									if (!$icmsAdminTpl->template_touch($newtplid)) {
+									if (!icms_view_Tpl::template_touch($newtplid)) {
 										$msgs[] = sprintf('&nbsp;&nbsp;<span style="color:#ff0000;">' . _MD_AM_TEMPLATE_COMPILE_FAIL . '</span>',
 											'<strong>' . $block['template'] . '</strong>', '<strong>' . icms_conv_nr2local($newtplid) . '</strong>');
 									} else {
@@ -1108,7 +1108,7 @@ function icms_module_update($dirname) {
 						$newid = $tplfile->getVar('tpl_id');
 						$msgs[] = sprintf('&nbsp;&nbsp;<span>' . _MD_AM_TEMPLATE_INSERTED . '</span>', '<strong>' . $tpl['file'] . '</strong>', '<strong>' . $newid . '</strong>');
 						if ($icmsConfig['template_set'] == 'default') {
-							if (!$icmsAdminTpl->template_touch($newid)) {
+							if (!icms_view_Tpl::template_touch($newid)) {
 								$msgs[] = sprintf('&nbsp;&nbsp;<span style="color:#ff0000;">'
 								. _MD_AM_TEMPLATE_RECOMPILE_FAIL . '</span>', '<strong>' . $tpl['file'] . '</strong>');
 							} else {
@@ -1190,7 +1190,7 @@ function icms_module_update($dirname) {
 								} else {
 									$msgs[] = sprintf('&nbsp;&nbsp;' . _MD_AM_TEMPLATE_UPDATED, '<strong>' . $block['template'] . '</strong>');
 									if ($icmsConfig['template_set'] == 'default') {
-										if (!$icmsAdminTpl->template_touch($tplfile_new->getVar('tpl_id'))) {
+										if (!icms_view_Tpl::template_touch($tplfile_new->getVar('tpl_id'))) {
 											$msgs[] = sprintf('&nbsp;&nbsp;<span style="color:#ff0000;">'
 												. _MD_AM_TEMPLATE_RECOMPILE_FAIL . '</span>', '<strong>' . $block['template'] . '</strong>');
 										} else {
@@ -1255,7 +1255,7 @@ function icms_module_update($dirname) {
 									$msgs[] = sprintf('&nbsp;&nbsp;' . _MD_AM_TEMPLATE_INSERTED,
 										'<strong>' . $block['template'] . '</strong>', '<strong>' . $newid . '</strong>');
 									if ($icmsConfig['template_set'] == 'default') {
-										if (!$icmsAdminTpl->template_touch($newid)) {
+										if (!icms_view_Tpl::template_touch($newid)) {
 											$msgs[] = sprintf('&nbsp;&nbsp;<span style="color:#ff0000;">' . _MD_AM_TEMPLATE_RECOMPILE_FAIL . '</span>',
 												'<strong>' . $block['template'] . '</strong>');
 										} else {

--- a/modules/system/admin/modules/modules.php
+++ b/modules/system/admin/modules/modules.php
@@ -272,7 +272,7 @@ function xoops_module_install($dirname) {
 						unset($tpldata);
 					}
 				}
-				$icmsAdminTpl->template_clear_module_cache($newmid);
+				icms_view_Tpl::template_clear_module_cache($newmid);
 				$blocks = $module->getInfo('blocks');
 				if ($blocks !== FALSE) {
 					$msgs[] = _MD_AM_BLOCKS_ADDING;
@@ -674,7 +674,7 @@ function xoops_module_uninstall($dirname) {
 	$module_handler = icms::handler('icms_module');
 	$module =& $module_handler->getByDirname($dirname);
 	$module->registerClassPath();
-	$icmsAdminTpl->template_clear_module_cache($module->getVar('mid'));
+	icms_view_Tpl::template_clear_module_cache($module->getVar('mid'));
 	if ($module->getVar('dirname') == 'system') {
 		return "<p>" . sprintf(_MD_AM_FAILUNINS, "<strong>" . $module->getVar('name') . "</strong>")
 		. "&nbsp;" . _MD_AM_ERRORSC . "<br /> - " . _MD_AM_SYSNO . "</p>";
@@ -923,7 +923,7 @@ function xoops_module_activate($mid) {
 	global $icms_block_handler, $icmsAdminTpl;
 	$module_handler = icms::handler('icms_module');
 	$module =& $module_handler->get($mid);
-	$icmsAdminTpl->template_clear_module_cache($module->getVar('mid'));
+	icms_view_Tpl::template_clear_module_cache($module->getVar('mid'));
 	$module->setVar('isactive', 1);
 	if (!$module_handler->insert($module)) {
 		$ret = "<p>" . sprintf(_MD_AM_FAILACT, "<strong>" . $module->getVar('name') . "</strong>") . "&nbsp;"
@@ -956,7 +956,7 @@ function xoops_module_deactivate($mid) {
 
 	$module_handler = icms::handler('icms_module');
 	$module =& $module_handler->get($mid);
-	$icmsAdminTpl->template_clear_module_cache($mid);
+	icms_view_Tpl::template_clear_module_cache($mid);
 	$module->setVar('isactive', 0);
 	if ($module->getVar('dirname') == "system") {
 		return "<p>" . sprintf(_MD_AM_FAILDEACT, "<strong>" . $module->getVar('name') . "</strong>")
@@ -1038,11 +1038,8 @@ function icms_module_update($dirname) {
 	// Save current version for use in the update function
 	$prev_version = $module->getVar('version');
 	$prev_dbversion = $module->getVar('dbversion');
-	/**
-	 * http://www.php.net/manual/en/language.oop5.paamayim-nekudotayim.php
-	 * @todo PHP5.3.0 supports $icmsAdminTpl::template_clear_module_cache($module->getVar('mid'));
-	 */
-	$icmsAdminTpl->template_clear_module_cache($module->getVar('mid'));
+
+	icms_view_Tpl::template_clear_module_cache($module->getVar('mid'));
 	// we dont want to change the module name set by admin
 	$temp_name = $module->getVar('name');
 	$module->loadInfoAsVar($dirname);

--- a/modules/system/admin/preferences.php
+++ b/modules/system/admin/preferences.php
@@ -605,17 +605,17 @@ switch ($op) {
 							$dtemplates = & $tplfile_handler->find('default', 'block');
 							$dcount = count($dtemplates);
 
-							// need to do this to pass to $icmsAdminTpl->template_touch function
+							// need to do this to pass to icms_view_Tpl::template_touch function
 							$GLOBALS['icmsConfig']['template_set'] = $newtplset;
 
 							for ($i = 0; $i < $dcount; $i++) {
 								$found = & $tplfile_handler->find($newtplset, 'block', $dtemplates[$i]->getVar('tpl_refid'), NULL);
 								if (count($found) > 0) {
 									// template for the new theme found, compile it
-									$icmsAdminTpl->template_touch($found[0]->getVar('tpl_id'));
+									icms_view_Tpl::template_touch($found[0]->getVar('tpl_id'));
 								} else {
 									// not found, so compile 'default' template file
-									$icmsAdminTpl->template_touch($dtemplates[$i]->getVar('tpl_id'));
+									icms_view_Tpl::template_touch($dtemplates[$i]->getVar('tpl_id'));
 								}
 							}
 						}

--- a/modules/system/admin/tplsets.php
+++ b/modules/system/admin/tplsets.php
@@ -315,7 +315,7 @@ switch ($op) {
 						}
 					}
 					if ($tplfile->getVar('tpl_tplset') == $icmsConfig['template_set']) {
-						$icmsAdminTpl->template_touch($id);
+						icms_view_Tpl::template_touch($id);
 					}
 				}
 			} else {
@@ -362,8 +362,7 @@ switch ($op) {
 					if ($tplfile->getVar('tpl_tplset') == $icmsConfig['template_set']) {
 						$defaulttpl =& $tpltpl_handler->find('default', $tplfile->getVar('tpl_type'), $tplfile->getVar('tpl_refid'), NULL, $tplfile->getVar('tpl_file'));
 						if (count($defaulttpl) > 0) {
-
-							$icmsAdminTpl->template_touch($defaulttpl[0]->getVar('tpl_id'), TRUE);
+							icms_view_Tpl::template_touch($defaulttpl[0]->getVar('tpl_id'));
 						}
 					}
 				}
@@ -634,7 +633,7 @@ switch ($op) {
 			} else {
 				if ($tplset == $icmsConfig['template_set']) {
 
-					$icmsAdminTpl->template_touch($newtpl->getVar('tpl_id'));
+					icms_view_Tpl::template_touch($newtpl->getVar('tpl_id'));
 				}
 			}
 		} else {
@@ -678,8 +677,7 @@ switch ($op) {
 					. _ERROR . ': ' . sprintf(_MD_TPLSET_INSERT_FAILED, '<strong>' . $file . '</strong>') . '</span><br />';
 				} else {
 					if ($tplset == $icmsConfig['template_set']) {
-
-						$icmsAdminTpl->template_touch($newtpl->getVar('tpl_id'));
+						icms_view_Tpl::template_touch($newtpl->getVar('tpl_id'));
 					}
 					echo '&nbsp;&nbsp;' . sprintf(_MD_TPLSET_INSERT_OK, '<strong>' . $tplfiles[$i]->getVar('tpl_file') . '</strong>') . '<br />';
 				}
@@ -705,8 +703,7 @@ switch ($op) {
 					echo $newtpl->getHtmlErrors();
 				} else {
 					if ($tplset == $icmsConfig['template_set']) {
-
-						$icmsAdminTpl->template_touch($newtpl->getVar('tpl_id'));
+						icms_view_Tpl::template_touch($newtpl->getVar('tpl_id'));
 					}
 					echo '&nbsp;&nbsp;&nbsp;&nbsp;' . sprintf(_MD_TPLSET_BLOCK_INSERT_OK, '<strong>' . $tplfiles[$i]->getVar('tpl_file') . '</strong>') . '<br />';
 				}
@@ -966,7 +963,7 @@ switch ($op) {
 						$msg[] = sprintf(_MD_TPLSET_UPDATED, '<strong>' . $upload_file . '</strong>');
 						if ($tplset == $icmsConfig['template_set']) {
 
-							if ($icmsAdminTpl->template_touch($tpl->getVar('tpl_id'), TRUE)) {
+							if (icms_view_Tpl::template_touch($tpl->getVar('tpl_id'))) {
 								$msg[] = sprintf(_MD_TPLSET_COMPILED, '<strong>' . $upload_file . '</strong>');
 							}
 						}


### PR DESCRIPTION
Calling static methods as non-static still works but it is bad thing to do. This pull request fixes such issue at least for few methods `template_touch` and `template_clear_module_cache` .