### PR TITLE
.scrutinizer.yml now use same code style as .travis.yml + some other improvements

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,115 +1,114 @@
 before_commands:
-    - "composer install --prefer-dist"
+  - "composer install --prefer-dist"
 filter:
-    paths:
-        - modules/
-        - include/
-        - plugins/
-        - libraries/icms/
-        - libraries/icms.php
-        - htdocs/install/
-        - htdocs/editors/
-        - mainfile.php
-        - extras/plugins/
-        - libraries/phpopenid
-        - libraries/recaptcha/
-        - admin.php
-        - cmd.php
-        - content.php
-        - edituser.php
-        - htdocs/error.php
-        - finish_auth.php
-        - footer.php
-        - header.php
-        - image.php
-        - htdocs/index.php
-        - invite.php
-        - lostpass.php
-        - misc.php
-        - notifications.php
-        - pmlite.php
-        - privpolicy.php
-        - readpmsg.php
-        - register.php
-        - resetpass.php
-        - search.php
-        - session_confirm.php
-        - suggest.php
-        - try_auth.php
-        - user.php
-        - userinfo.php
-        - viewpmsg.php
-    dependency_paths:
-        - libraries/smarty/
-        - libraries/phpopenid/Auth/
-        - libraries/geshi/
-        - libraries/phpopenid/admin/
-        - libraries/wideimage/
-        - libraries/xml/rss/
-        - libraries/recaptcha/
-        - libraries/paginationstyles/
-        - libraries/xml/
-        - vendor/
-    excluded_paths:
-        - vendor/
+  paths:
+    - modules/
+    - include/
+    - plugins/
+    - libraries/icms/
+    - libraries/icms.php
+    - htdocs/install/
+    - htdocs/editors/
+    - mainfile.php
+    - extras/plugins/
+    - admin.php
+    - cmd.php
+    - content.php
+    - edituser.php
+    - htdocs/error.php
+    - finish_auth.php
+    - footer.php
+    - header.php
+    - image.php
+    - htdocs/index.php
+    - invite.php
+    - lostpass.php
+    - misc.php
+    - notifications.php
+    - pmlite.php
+    - privpolicy.php
+    - readpmsg.php
+    - register.php
+    - resetpass.php
+    - search.php
+    - session_confirm.php
+    - suggest.php
+    - try_auth.php
+    - user.php
+    - userinfo.php
+    - viewpmsg.php
+  dependency_paths:
+    - vendor/
+  excluded_paths:
+    - vendor/
 checks:
-    php:
-        duplication: true
-        unused_methods: false
-        unused_parameters: true
-        argument_type_checks: false
-        verify_property_names: false
-        method_calls_on_non_object: true
-        fix_doc_comments: false
-        instanceof_class_exists: false
-        catch_class_exists: false
-        assignment_of_null_return: false
-        use_statement_alias_conflict: false
+  php:
+    duplication: true
+    unused_methods: false
+    unused_parameters: true
+    argument_type_checks: false
+    verify_property_names: false
+    method_calls_on_non_object: true
+    fix_doc_comments: false
+    instanceof_class_exists: false
+    catch_class_exists: false
+    assignment_of_null_return: false
+    use_statement_alias_conflict: false
 tools:
-    php_sim:
-        enabled: true
-        min_mass: 50             # Defaults to 16
+  php_sim:
+    enabled: true
+    min_mass: 50 # Defaults to 16
 coding_style:
-    php:
-        indentation:
-            general:
-                use_tabs: true
-                size: 4
-            switch:
-                indent_case: true
-        spaces:
-            around_operators:
-                concatenation: true
-            ternary_operator:
-                before_condition: false
-                after_condition: false
-                before_alternative: false
-                after_alternative: false
-        braces:
-            classes_functions:
-                class: end-of-line
-                function: end-of-line
-                closure: end-of-line
-            if:
-                opening: end-of-line
-            for:
-                opening: end-of-line
-            while:
-                opening: end-of-line
-            do_while:
-                opening: end-of-line
-            switch:
-                opening: end-of-line
-            try:
-                opening: end-of-line
-        upper_lower_casing:
-            keywords:
-                general: lower
-            constants:
-                true_false_null: lower
+  php:
+    indentation:
+      general:
+        use_tabs: true
+        size: 4
+      switch:
+        indent_case: true
+    spaces:
+      around_operators:
+        concatenation: true
+      ternary_operator:
+        before_condition: false
+        after_condition: false
+        before_alternative: false
+        after_alternative: false
+    braces:
+      classes_functions:
+        class: end-of-line
+        function: end-of-line
+        closure: end-of-line
+      if:
+        opening: end-of-line
+      for:
+        opening: end-of-line
+      while:
+        opening: end-of-line
+      do_while:
+        opening: end-of-line
+      switch:
+        opening: end-of-line
+      try:
+        opening: end-of-line
+    upper_lower_casing:
+      keywords:
+        general: lower
+      constants:
+        true_false_null: lower
 build:
-    nodes:
-        analysis:
-            tests:
-                override:
-                    - php-scrutinizer-run
+  environment:
+    postgresql: false
+    php: 7.2.0
+    mongodb: false
+    redis: false
+    memcached: false
+    neo4j: false
+    rabbitmq: false
+  nodes:
+    analysis:
+      project_setup:
+        override: true
+      tests:
+        override:
+          - php-scrutinizer-run --enable-security-analysis


### PR DESCRIPTION
This:
 * removes some paths that where added to composer
 * use same code style as .travis.yml
 * disable postgresql, mongodb, redis, memcached, neo4j, rabbitmq
 * PHP now 7.2.0 (not anymore 5.5)
 * --enable-security-analysis