### PR TITLE
version number is not shown for uninstalled modules

### DIFF
--- a/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
+++ b/htdocs/modules/system/admin/modulesadmin/modulesadmin.php
@@ -108,7 +108,7 @@ function xoops_module_list() {
 				'dirname' => $module->getInfo('dirname'),
 				'name' => $module->getInfo('name'),
 				'image' => $module->getInfo('image'),
-				'version' => icms_conv_nr2local($module->getVar('version')),
+				'version' => $module->getInfo('version'),
 				'status' => $module->getInfo('status'),
 			);
 			$icmsAdminTpl->append('avmodules', $mod);


### PR DESCRIPTION
fix #338