### PR TITLE
Adjusting code tag processing to accurately handle pre-existing content

### DIFF
--- a/htdocs/libraries/icms/core/DataFilter.php
+++ b/htdocs/libraries/icms/core/DataFilter.php
@@ -772,7 +772,7 @@ class icms_core_DataFilter {
 		if ($imcode != 0) {
 			$patterns = "/\[code](.*)\[\/code\]/sU";
 			$text = preg_replace_callback($patterns, function ($match) {
-				return base64_encode($match[1]);
+				return '[code]' . base64_encode($match[1]) . '[/code]';
 			}, $text);
 		}
 		return $text;
@@ -790,8 +790,8 @@ class icms_core_DataFilter {
 		if ($imcode != 0) {
 			$patterns = "/\[code](.*)\[\/code\]/sU";
 			$text = preg_replace_callback($patterns, function ($matches) use ($image) {
-				$code = icms_core_DataFilter::codeSanitizer($matches[1],($image != 0)?1:0);
-				return '<div class=\"icmsCode\">' . $code . '</div>';
+				$code = icms_core_DataFilter::codeSanitizer($matches[1],($image != 0) ? 1 : 0);
+				return '<div class="icmsCode">' . $code . '</div>';
 			}, $text);
 		}
 		return $text;


### PR DESCRIPTION
fix #361

the code tags were not being preserved, so the final result was just base64 encoded. The css style for the div had extra characters in it, so it did not render properly.