### PR TITLE
Update Group permission Handler.php for strict PHP

### DIFF
--- a/htdocs/libraries/icms/member/groupperm/Handler.php
+++ b/htdocs/libraries/icms/member/groupperm/Handler.php
@@ -55,7 +55,7 @@ defined('ICMS_ROOT_PATH') or die("ImpressCMS root path not defined");
  * @copyright	Copyright (c) 2000 XOOPS.org
  */
 class icms_member_groupperm_Handler extends icms_core_ObjectHandler {
-	static public $_cachedRights;
+	public $_cachedRights;
 
 	/**
 	 * Create a new {@link icms_member_groupperm_Object}


### PR DESCRIPTION
Fix PHP Strict error : Strict: Accessing static property icms_member_groupperm_Handler::$_cachedRights as non static in file /libraries/icms/member/groupperm/Handler.php line 390

the $_cachedRights variable was not static