### PR TITLE
removed many unused now disallows from robots.txt file

### DIFF
--- a/htdocs/robots.txt
+++ b/htdocs/robots.txt
@@ -1,16 +1,5 @@
 User-agent: *
-Disallow: /cgi-bin/
-Disallow: /tmp/
-Disallow: /cache/
-Disallow: /class/
 Disallow: /editors/
-Disallow: /images/
-Disallow: /include/
 Disallow: /install/
-Disallow: /kernel/
-Disallow: /language/
-Disallow: /libraries/
-Disallow: /plugins/
-Disallow: /templates_c/
 Disallow: /themes/
 Disallow: /uploads/


### PR DESCRIPTION
There was some disallows that for 2.x structure doesn't make sense in robots.txt file. So, removed.