### PR TITLE
Correcting static property reference. Fix #472

### DIFF
--- a/htdocs/libraries/icms/member/groupperm/Handler.php
+++ b/htdocs/libraries/icms/member/groupperm/Handler.php
@@ -379,18 +379,18 @@ class icms_member_groupperm_Handler extends icms_core_ObjectHandler {
 	public function getGroupIds($gperm_name, $gperm_itemid, $gperm_modid = 1) {
 		$ret = array();
 		$perms = array();
-		if (isset(self::_cachedRights[$gperm_name][$gperm_itemid][$gperm_modid])) {
-			$perms = self::_cachedRights[$gperm_name][$gperm_itemid][$gperm_modid];
+		if (isset(self::$_cachedRights[$gperm_name][$gperm_itemid][$gperm_modid])) {
+			$perms = self::$_cachedRights[$gperm_name][$gperm_itemid][$gperm_modid];
 		} else {
 			$criteria = new icms_db_criteria_Compo(new icms_db_criteria_Item('gperm_name', $gperm_name));
 			$criteria->add(new icms_db_criteria_Item('gperm_itemid', (int) $gperm_itemid));
 			$criteria->add(new icms_db_criteria_Item('gperm_modid', (int) $gperm_modid));
 			$perms = $this->getObjects($criteria, true);
-			foreach ( $perms as $perm) {
-				self::_cachedRights[$gperm_name][$gperm_itemid][$gperm_modid][] = $perm;
+			foreach ($perms as $perm) {
+				self::$_cachedRights[$gperm_name][$gperm_itemid][$gperm_modid][] = $perm;
 	  		}
 		}
-		foreach ( array_keys($perms) as $i) {
+		foreach (array_keys($perms) as $i) {
 			$ret[] = $perms[$i]->getVar('gperm_groupid');
 		}
 		return $ret;


### PR DESCRIPTION
The change to comply with strict mode was incomplete - I missed the property indicator '$'. This adds that and the install continues successfully on PHP 5.6