### PR TITLE
make expiration header dynamic in the past

### DIFF
--- a/htdocs/footer.php
+++ b/htdocs/footer.php
@@ -84,7 +84,7 @@ if (isset($xoopsOption['theme_use_smarty']) && $xoopsOption['theme_use_smarty'] 
 
 	if (!headers_sent()) {
 		header('Content-Type:text/html; charset=' . _CHARSET);
-		header('Expires: Mon, 26 Jul 1997 05:00:00 GMT');
+		header('Expires:' . gmdate("D, d M Y H:i:s T", strtotime("yesterday")) );
 		header('Cache-Control: private, no-cache');
 		header('Pragma: no-cache');
 	}


### PR DESCRIPTION
Believe it or not, but Chrome didn't like the date to be too far in the past. Now the login works as expected in Chrome and the Chromium-based Edge.

Fix #100 