### PR TITLE
Fixed suppressed warning if variable $options['folderName'] is undefined or empty when creating theme (1.4.x)

### DIFF
--- a/htdocs/libraries/icms/view/theme/Factory.php
+++ b/htdocs/libraries/icms/view/theme/Factory.php
@@ -84,7 +84,7 @@ class icms_view_theme_Factory {
 				}
 			} elseif (isset($_SESSION[$this->xoBundleIdentifier]['defaultTheme'])) {
 				$options['folderName'] = $_SESSION[$this->xoBundleIdentifier]['defaultTheme'];
-			} elseif (@empty($options['folderName'] ) || ! $this->isThemeAllowed($options ['folderName'])) {
+			} elseif (!isset($options['folderName']) || empty($options['folderName']) || !$this->isThemeAllowed($options['folderName'])) {
 				$options['folderName'] = $this->defaultTheme;
 			}
 			$GLOBALS['icmsConfig']['theme_set'] = $options['folderName'];


### PR DESCRIPTION
Just a small code improvement.