### PR TITLE
Fixed function signatures in icms_image_Handler (1.4)

### DIFF
--- a/htdocs/libraries/icms/image/Handler.php
+++ b/htdocs/libraries/icms/image/Handler.php
@@ -207,12 +207,15 @@ class icms_image_Handler extends icms_core_ObjectHandler {
 	/**
 	 * Load {@link icms_image_Object}s from the database
 	 *
-	 * @param   object  $criteria   {@link icms_db_criteria_Element}
-	 * @param   boolean $id_as_key  Use the ID as key into the array
-	 * @param   boolean $getbinary
-	 * @return  array   Array of {@link icms_image_Object} objects
-	 **/
-	public function getObjects($criteria = null, $id_as_key = false, $getbinary = false) {
+	 * @param null|icms_db_criteria_Item $criteria {@link icms_db_criteria_Element}
+	 * @param bool $id_as_key Use the ID as key into the array
+	 * @param bool $getbinary Get binary image?
+	 * @param bool|string $sql  Extra sql (unused; only used for compatibility function signature)
+	 * @param bool $debug Debug mode?
+	 *
+	 * @return icms_image_Object[]
+	 */
+	public function getObjects($criteria = null, $id_as_key = false, $getbinary = false, $sql = false, $debug = false) {
 		$ret = array();
 		$limit = $start = 0;
 		if ($getbinary) {
@@ -228,6 +231,9 @@ class icms_image_Handler extends icms_core_ObjectHandler {
 			$sql .= " ORDER BY " . $sort . " " . $criteria->getOrder();
 			$limit = $criteria->getLimit();
 			$start = $criteria->getStart();
+		}
+		if ($debug) {
+			icms_core_Debug::message($sql);
 		}
 		$result = $this->db->query($sql, $limit, $start);
 		if (!$result) {
@@ -263,7 +269,7 @@ class icms_image_Handler extends icms_core_ObjectHandler {
 		list($count) = $this->db->fetchRow($result);
 		return $count;
 	}
-
+	
 	/**
 	 * Get a list of images
 	 *
@@ -272,7 +278,7 @@ class icms_image_Handler extends icms_core_ObjectHandler {
 	 * @param int $notinuse Not use param (only added for fixing Declaration of icms_image_Handler::getList($imgcat_id, $image_display = NULL, $notinuse1 = 0, $debug = false) should be compatible with icms_ipf_Handler::getList($criteria = NULL, $limit = 0, $start = 0, $debug = false) error)
 	 * @param bool $debug Enable debug mode?
 	 *
-	 * @return icms_image_Object[]
+	 * @return array Array of <a href='psi_element://icms_image_Object'>icms_image_Object</a> objects
 	 * objects
 	 *
 	 * @todo Do better fix here for declaration compatibility
@@ -287,7 +293,7 @@ class icms_image_Handler extends icms_core_ObjectHandler {
 		if ($image_display) {
 			$criteria->add(new icms_db_criteria_Item('image_display', (int) ($image_display)));
 		}
-		$images = & $this->getObjects($criteria, false, true, falsse, true);
+		$images = & $this->getObjects($criteria, false, true, false, true);
 		$ret = array();
 		foreach (array_keys($images) as $i) {
 			$ret[$images[$i]->getVar('image_name')] = $images[$i]->getVar('image_nicename');

--- a/htdocs/libraries/icms/image/Handler.php
+++ b/htdocs/libraries/icms/image/Handler.php
@@ -267,18 +267,29 @@ class icms_image_Handler extends icms_core_ObjectHandler {
 	/**
 	 * Get a list of images
 	 *
-	 * @param   int     $imgcat_id
-	 * @param   bool    $image_display
-	 * @return  array   Array of {@link icms_image_Object} objects
-	 **/
-	public function getList($imgcat_id, $image_display = null) {
-		$criteria = new icms_db_criteria_Compo(new icms_db_criteria_Item('imgcat_id', (int) ($imgcat_id)));
-		if (isset($image_display)) {
+	 * @param int|null $imgcat_id Image category ID
+	 * @param bool|null|int $image_display List only displayed images?
+	 * @param int $notinuse Not use param (only added for fixing Declaration of icms_image_Handler::getList($imgcat_id, $image_display = NULL, $notinuse1 = 0, $debug = false) should be compatible with icms_ipf_Handler::getList($criteria = NULL, $limit = 0, $start = 0, $debug = false) error)
+	 * @param bool $debug Enable debug mode?
+	 *
+	 * @return icms_image_Object[]
+	 * objects
+	 *
+	 * @todo Do better fix here for declaration compatibility
+	 */
+	public function getList($imgcat_id = null, $image_display = 0, $notinuse = 0, $debug = false) {
+		$criteria = new icms_db_criteria_Compo();
+		if ($imgcat_id !== null) {
+			$criteria->add(
+				new icms_db_criteria_Item('imgcat_id', (int) ($imgcat_id))
+			);
+		}
+		if ($image_display) {
 			$criteria->add(new icms_db_criteria_Item('image_display', (int) ($image_display)));
 		}
-		$images = &$this->getObjects($criteria, false, true);
+		$images = & $this->getObjects($criteria, false, true, falsse, true);
 		$ret = array();
-		foreach ( array_keys($images) as $i) {
+		foreach (array_keys($images) as $i) {
 			$ret[$images[$i]->getVar('image_name')] = $images[$i]->getVar('image_nicename');
 		}
 		return $ret;


### PR DESCRIPTION
getObjects and getList generated compatibility warnings because signatures from parent classes were so different. This pull request fixes this small problem.