### PR TITLE
Fixed PathStuffController's constructor

### DIFF
--- a/htdocs/install/page_pathsettings.php
+++ b/htdocs/install/page_pathsettings.php
@@ -25,8 +25,6 @@ $wizard->setPage( 'pathsettings' );
 $pageHasForm = true;
 $pageHasHelp = true;
 
-
-
 class PathStuffController {
 	var $xoopsRootPath = '';
 	var $xoopsTrustPath = '';
@@ -38,7 +36,7 @@ class PathStuffController {
 
 	var $permErrors = array();
 
-	function PathStuffController() {
+	function __construct() {
 		if (isset( $_SESSION['settings']['ROOT_PATH'] )) {
 			$this->xoopsRootPath = $_SESSION['settings']['ROOT_PATH'];
 		} else {


### PR DESCRIPTION
PathStuffController (for installer) used old style constructor. This fixes such issue.