### PR TITLE
Added 'stale' github action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 4 28 */2 *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue was automatically marked as stale'
+        stale-pr-message: 'This pull request was automatically marked as stale'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'


### PR DESCRIPTION
Every two months all pull requests and issues will be automatically rechecked and if they are very old marked as stale.  If this will work as expected, I think this will be a good indicator what haven't changed and must be looked into.