### PR TITLE
Removing wideimage directories and files

### DIFF
--- a/libraries/wideimage/index.html
+++ b/libraries/wideimage/index.html
@@ -1,1 +1,0 @@
- <script>history.go(-1);</script>

--- a/libraries/wideimage/lib/Font/index.html
+++ b/libraries/wideimage/lib/Font/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/libraries/wideimage/lib/Mapper/index.html
+++ b/libraries/wideimage/lib/Mapper/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/libraries/wideimage/lib/Operation/index.html
+++ b/libraries/wideimage/lib/Operation/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/libraries/wideimage/lib/index.html
+++ b/libraries/wideimage/lib/index.html
@@ -1,1 +1,0 @@
- <script>history.go(-1);</script>

--- a/libraries/wideimage/lib/vendor/JPEXS/index.html
+++ b/libraries/wideimage/lib/vendor/JPEXS/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/libraries/wideimage/lib/vendor/de77/index.html
+++ b/libraries/wideimage/lib/vendor/de77/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>

--- a/libraries/wideimage/lib/vendor/index.html
+++ b/libraries/wideimage/lib/vendor/index.html
@@ -1,1 +1,0 @@
-<script>history.go(-1);</script>


### PR DESCRIPTION
Somehow some wideimage index.html files where left in repo. This pull request is removing them.