### PR TITLE
@link comments fixed

### DIFF
--- a/include/functions.php
+++ b/include/functions.php
@@ -2148,7 +2148,7 @@ if (!function_exists('icms_buildCriteria')) {
 	 * Build criteria automatically from an array of key=>value
 	 *
 	 * @param array $criterias array of fieldname=>value criteria
-	 * @return object (@link icms_db_criteria_Compo) the icms_db_criteria_Compo object
+	 * @return icms_db_criteria_Element
 	 * @todo Move to a static class method - Criteria
 	 */
 	function icms_buildCriteria($criterias)

--- a/include/pdf.php
+++ b/include/pdf.php
@@ -14,10 +14,11 @@
 /**
  * Generates a pdf file
  *
- * @param string $content	The content to put in the PDF file
- * @param string $doc_title	The title for the PDF file
- * @param string $doc_keywords	The keywords to put in the PDF file
- * @return string Generated output by the pdf (@link TCPDF) class
+ * @param string $content The content to put in the PDF file
+ * @param string $doc_title The title for the PDF file
+ * @param string $doc_keywords The keywords to put in the PDF file
+ * @return string Generated output
+ * @throws ReflectionException
  */
 function Generate_PDF($content, $doc_title, $doc_keywords) {
 	global $icmsConfig;

--- a/libraries/icms/auth/method/Ldap.php
+++ b/libraries/icms/auth/method/Ldap.php
@@ -194,7 +194,7 @@ class icms_auth_method_Ldap extends icms_auth_Object {
 	/**
 	 * Load user from ImpressCMS Database
 	 * @param string $uname UserName
-	 * @return object {@link icms_member_user_Object} icms_member_user_Object object
+	 * @return \icms_member_user_Object
 	 */
 	public function getFilter($uname) {
 		$filter = '';
@@ -211,7 +211,7 @@ class icms_auth_method_Ldap extends icms_auth_Object {
 	 * @param string $userdn
 	 * @param string $uname Username
 	 * @param string $pwd Password
-	 * @return object {@link icms_member_user_Object} icms_member_user_Object object
+	 * @return \icms_member_user_Object
 	 */
 	public function getMember($userdn, $uname, $pwd = null) {
 		$provisHandler = icms_auth_method_ldap_Provisioning::getInstance($this);

--- a/libraries/icms/auth/method/Local.php
+++ b/libraries/icms/auth/method/Local.php
@@ -28,7 +28,7 @@ class icms_auth_method_Local extends icms_auth_Object {
 	 * Authenticate user
 	 * @param string $uname
 	 * @param string $pwd
-	 * @return object {@link icms_member_user_Object} icms_member_user_Object object
+	 * @return \icms_member_user_Object
 	 */
 	public function authenticate($uname, $pwd = null) {
 		$member_handler = icms::handler('icms_member');

--- a/libraries/icms/auth/method/ldap/Provisioning.php
+++ b/libraries/icms/auth/method/ldap/Provisioning.php
@@ -18,9 +18,9 @@ class icms_auth_method_ldap_Provisioning {
 	private $_auth_instance;
 
 	/**
-	 * Gets instance of {@link icms_auth_method_ldap_Provisioning}
+	 * Gets instance
 	 * @param   object $auth_instance
-	 * @return  object $provis_instance {@link icms_auth_method_ldap_Provisioning}
+	 * @return  \icms_auth_method_ldap_Provisioning
 	 */
 	static public function &getInstance(&$auth_instance) {
 		static $provis_instance;
@@ -32,7 +32,7 @@ class icms_auth_method_ldap_Provisioning {
 
 	/**
 	 * Authentication Service constructor
-	 * @param object $auth_instance {@link icms_auth_method_ldap_Provisioning}
+	 * @param \icms_auth_method_ldap_Provisioning $auth_instance icms_auth_method_ldap_Provisioning instance
 	 */
 	public function __construct(&$auth_instance) {
 		$this->_auth_instance = &$auth_instance;
@@ -49,7 +49,7 @@ class icms_auth_method_ldap_Provisioning {
 	/**
 	 * Return a User Object
 	 * @param   string $uname Username of the user
-	 * @return  mixed icms_member_user_Object {@link icms_member_user_Object} or false if failed
+	 * @return  \icms_member_user_Object|false icms_member_user_Object or false if failed
 	 */
 	public function geticms_member_user_Object($uname) {
 		$member_handler = icms::handler('icms_member');
@@ -67,7 +67,7 @@ class icms_auth_method_ldap_Provisioning {
 	 * @param array $datas Some Data
 	 * @param string $uname Username of the user
 	 * @param string $pwd Password of the user
-	 * @return object icms_member_user_Object {@link icms_member_user_Object}
+	 * @return \icms_member_user_Object icms_member_user_Object
 	 */
 	public function sync($datas, $uname, $pwd = null) {
 		$icmsUser = $this->geticms_member_user_Object($uname);
@@ -130,11 +130,11 @@ class icms_auth_method_ldap_Provisioning {
 
 	/**
 	 * Modify user information
-	 * @param object {@link icms_member_user_Object} reference to icms_member_user_Object Object
+	 * @param icms_member_user_Object $icmsUser reference
 	 * @param array $datas Some Data
 	 * @param string $uname Username of the user
 	 * @param string $pwd Password of the user
-	 * @return object icms_member_user_Object {@link icms_member_user_Object}
+	 * @return \icms_member_user_Object
 	 */
 	public function change(&$icmsUser, $datas, $uname, $pwd = null) {
 		$ret = false;

--- a/libraries/icms/config/Handler.php
+++ b/libraries/icms/config/Handler.php
@@ -156,7 +156,7 @@ class icms_config_Handler {
 	 * Create a config
 	 *
 	 * @see     icms_config_Item_Object
-	 * @return	object  reference to the new {@link icms_config_Item_Object}
+	 * @return	\icms_config_Item_Object
 	 */
 	public function &createConfig() {
 		$instance = & $this->_cHandler->create();
@@ -168,7 +168,7 @@ class icms_config_Handler {
 	 *
 	 * @param	int     $id             ID of the config
 	 * @param	bool    $withoptions    load the config's options now?
-	 * @return	object  reference to the {@link icms_config_Item_Object}
+	 * @return	\icms_config_Item_Object
 	 */
 	public function &getConfig($id, $withoptions = false) {
 		$config = & $this->_cHandler->get($id);
@@ -181,7 +181,7 @@ class icms_config_Handler {
 	/**
 	 * insert a new config in the database
 	 *
-	 * @param	object  &$config    reference to the {@link icms_config_Item_Object}
+	 * @param	\icms_config_Item_Object  &$config    reference
 	 * @return	true|false if inserting config succeeded or not
 	 */
 	public function insertConfig(&$config) {
@@ -209,8 +209,8 @@ class icms_config_Handler {
 	/**
 	 * Delete a config from the database
 	 *
-	 * @param	object  &$config    reference to a {@link icms_config_Item_Object}
-	 * @return	true|false if deleting config item succeeded or not
+	 * @param	\icms_config_Item_Object  &$config    refence
+	 * @return	bool if deleting config item succeeded or not
 	 */
 	public function deleteConfig(&$config) {
 		if (!$this->_cHandler->delete($config)) {
@@ -236,11 +236,11 @@ class icms_config_Handler {
 	/**
 	 * get one or more Configs
 	 *
-	 * @param	object  $criteria       {@link icms_db_criteria_Element}
+	 * @param	\icms_db_criteria_Element  $criteria      Criteria
 	 * @param	bool    $id_as_key      Use the configs' ID as keys?
 	 * @param	bool    $with_options   get the options now?
 	 *
-	 * @return	array   Array of {@link icms_config_Item_Object} objects
+	 * @return	\icms_config_Item_Object[]
 	 */
 	public function getConfigs($criteria = null, $id_as_key = false, $with_options = false) {
 		return $this->_cHandler->getObjects($criteria, $id_as_key);
@@ -249,7 +249,7 @@ class icms_config_Handler {
 	/**
 	 * Count some configs
 	 *
-	 * @param	object  $criteria   {@link icms_db_criteria_Element}
+	 * @param	\icms_db_criteria_Element  $criteria   Criteria
 	 * @return	int count result
 	 */
 	public function getConfigCount($criteria = null) {
@@ -262,7 +262,7 @@ class icms_config_Handler {
 	 * @param	int $category   ID of a category
 	 * @param	int $module     ID of a module
 	 *
-	 * @return	array   array of {@link icms_config_Item_Object}s
+	 * @return	\icms_config_Item_Object[]
 	 */
 	public function &getConfigsByCat($category, $module = 0) {
 		if (is_array($category)) {
@@ -300,9 +300,9 @@ class icms_config_Handler {
 	}
 
 	/**
-	 * Make a new {@link icms_config_option_Object}
+	 * Make a new
 	 *
-	 * @return	object  {@link icms_config_option_Object}
+	 * @return	\icms_config_option_Object
 	 */
 	public function &createConfigOption() {
 		$inst = & $this->_oHandler->create();
@@ -310,11 +310,11 @@ class icms_config_Handler {
 	}
 
 	/**
-	 * Get a {@link icms_config_option_Object}
+	 * Get a option by id
 	 *
 	 * @param	int $id ID of the config option
 	 *
-	 * @return	object  {@link icms_config_option_Object}
+	 * @return	\icms_config_option_Object
 	 */
 	public function &getConfigOption($id) {
 		$inst = & $this->_oHandler->get($id);
@@ -322,23 +322,23 @@ class icms_config_Handler {
 	}
 
 	/**
-	 * Get one or more {@link icms_config_option_Object}s
+	 * Get one or more object(s)
 	 *
-	 * @param	object  $criteria   {@link icms_db_criteria_Element}
+	 * @param	\icms_db_criteria_Element  $criteria   Criteria
 	 * @param	bool    $id_as_key  Use IDs as keys in the array?
 	 *
-	 * @return	array   Array of {@link icms_config_option_Object}s
+	 * @return	\icms_config_option_Object[]
 	 */
 	public function getConfigOptions($criteria = null, $id_as_key = false) {
 		return $this->_oHandler->getObjects($criteria, $id_as_key);
 	}
 
 	/**
-	 * Count some {@link icms_config_option_Object}s
+	 * Count
 	 *
-	 * @param	object  $criteria   {@link icms_db_criteria_Element}
+	 * @param	\icms_db_criteria_Element|null  $criteria   Criteria or null if none criteria should be used
 	 *
-	 * @return	int     Count of {@link icms_config_option_Object}s matching $criteria
+	 * @return	int
 	 */
 	public function getConfigOptionsCount($criteria = null) {
 		return $this->_oHandler->getCount($criteria);

--- a/libraries/icms/config/item/Object.php
+++ b/libraries/icms/config/item/Object.php
@@ -181,9 +181,9 @@ class icms_config_item_Object extends icms_ipf_Object {
 	}
 
 	/**
-	 * Assign one or more {@link icms_config_Item_ObjectOption}s
+	 * Assign one or more
 	 *
-	 * @param	mixed   $option either a {@link icms_config_Item_ObjectOption} object or an array of them
+	 * @param	icms_config_Item_ObjectOption|icms_config_Item_ObjectOption[]
 	 */
 	public function setConfOptions($option) {
 		if (is_array($option)) {
@@ -199,9 +199,9 @@ class icms_config_item_Object extends icms_ipf_Object {
 	}
 
 	/**
-	 * Get the {@link icms_config_Item_ObjectOption}s of this Config
+	 * Get the options of this Config
 	 *
-	 * @return	array   array of {@link icms_config_Item_ObjectOption}
+	 * @return	\icms_config_Item_ObjectOption[]
 	 */
 	public function &getConfOptions() {
 		return $this->_confOptions;

--- a/libraries/icms/core/DataFilter.php
+++ b/libraries/icms/core/DataFilter.php
@@ -126,7 +126,7 @@ class icms_core_DataFilter {
 	}
 
 	/**
-	 * Reverses {@link htmlSpecialChars()}
+	 * Reverses htmlSpecialChars
 	 *
 	 * @param   string  $text
 	 * @return  string
@@ -136,8 +136,11 @@ class icms_core_DataFilter {
 	}
 
 	/**
+	 * Converts text string with HTML entities
 	 *
-	 * @param unknown_type $text
+	 * @param string $text Text to add HTML entities
+	 *
+	 * @return string|string[]|null
 	 */
 	static public function htmlEntities($text) {
 		return preg_replace(array("/&amp;/i", "/&nbsp;/i"), array('&', '&amp;nbsp;'),
@@ -790,11 +793,10 @@ class icms_core_DataFilter {
 	/**
 	 * This function gets allowed plugins from DB and loads them in the sanitizer
 	 *
-	 * @copyright	(c) 2007-2010 The ImpressCMS Project - www.impresscms.org
-	 *
-	 * @param	int	 $id			 ID of the config
-	 * @param	bool	$withoptions	load the config's options now?
-	 * @return	object  reference to the {@link IcmsConfig}
+	 * @param string $text Plugin name
+	 * @param int $allowimage Allow image?
+	 * @return string
+	 * @copyright    (c) 2007-2010 The ImpressCMS Project - www.impresscms.org
 	 */
 	static public function codeDecode_extended($text, $allowimage = 1) {
 		global $icmsConfigPlugins;
@@ -827,7 +829,7 @@ class icms_core_DataFilter {
 	 *
 	 * @param	 string	$name	 Name of the file to load
 	 * @param	 string	$text	 Text to show if the function doesn't exist
-	 * @return	array	 the return of the called function
+	 * @return	string	 the return of the called function
 	 */
 	static public function executeExtension($name, $text) {
 		self::loadExtension($name);

--- a/libraries/icms/core/Logger.php
+++ b/libraries/icms/core/Logger.php
@@ -47,7 +47,7 @@ class icms_core_Logger {
 	/**
 	 * Get a reference to the only instance of this class
 	 *
-	 * @return  object icms_core_Logger  (@link icms_core_Logger) reference to the only instance
+	 * @return  static
 	 * @static
 	 */
 	static public function &instance()

--- a/libraries/icms/core/ObjectHandler.php
+++ b/libraries/icms/core/ObjectHandler.php
@@ -54,10 +54,9 @@
 abstract class icms_core_ObjectHandler {
 
 	/**
-	 * holds referenced to {@link icms_db_legacy_Database} class object
+	 * holds referenced
 	 *
-	 * @var object
-	 * @see icms_db_legacy_Database
+	 * @var icms_db_legacy_Database
 	 * @access public
 	 */
 	public $db;
@@ -66,7 +65,7 @@ abstract class icms_core_ObjectHandler {
 	/**
 	 * called from child classes only
 	 *
-	 * @param object $db reference to the {@link icms_db_legacy_Database} object
+	 * @param icms_db_legacy_Database $db reference to db
 	 * @access protected
 	 */
 	function __construct(&$db) {

--- a/libraries/icms/core/OnlineHandler.php
+++ b/libraries/icms/core/OnlineHandler.php
@@ -55,7 +55,7 @@ class icms_core_OnlineHandler {
 	/**
 	 * Constructor
 	 *
-	 * @param	object  &$db    {@link XoopsHandlerFactory}
+	 * @param	\icms_db_legacy_Database  &$db   Linked database instance
 	 */
 	public function __construct(&$db) {
 		$this->db = & $db;
@@ -137,8 +137,8 @@ class icms_core_OnlineHandler {
 	/**
 	 * Get an array of online information
 	 *
-	 * @param	object  $criteria   {@link icms_db_criteria_Element}
-	 * @return	array   Array of associative arrays of online information
+	 * @param \icms_db_criteria_Element|null $criteria Criteria
+	 * @return \icms_db_criteria_Element[]|bool
 	 */
 	public function getAll($criteria = null) {
 		$ret = array();
@@ -163,7 +163,8 @@ class icms_core_OnlineHandler {
 	/**
 	 * Count the number of online users
 	 *
-	 * @param	object  $criteria   {@link icms_db_criteria_Element}
+	 * @param \icms_db_criteria_Element $criteria Criteria
+	 * @return bool
 	 */
 	public function getCount($criteria = null) {
 		$sql = 'SELECT COUNT(*) FROM ' . $this->db->prefix('online');

--- a/libraries/icms/core/Security.php
+++ b/libraries/icms/core/Security.php
@@ -222,7 +222,9 @@ class icms_core_Security {
 	}
 
 	/**
-	 * Get the HTML code for a @link icms_form_elements_Hiddentoken object - used in forms that do not use XoopsForm elements
+	 * Get the HTML code for a token
+	 *
+	 * @param string $name Token field name
 	 *
 	 * @return string
 	 */

--- a/libraries/icms/data/comment/Handler.php
+++ b/libraries/icms/data/comment/Handler.php
@@ -57,9 +57,13 @@ class icms_data_comment_Handler extends icms_ipf_Handler {
 	/**
 	 * Get a list of comments
 	 *
-	 * @param   object  $criteria   {@link icms_db_criteria_Element}
+	 * @param \icms_db_criteria_Element|null $criteria Criteria
 	 *
-	 * @return  array   Array of raw database records
+	 * @param int $limit How many to get?
+	 * @param int $start From where to start?
+	 * @param bool $debug Debug action?
+	 *
+	 * @return  string[]
 	 */
 	public function getList($criteria = null, $limit, $start, $debug) {
 			$comments = parent::getList($criteria, $limit, $start, $debug);
@@ -76,7 +80,7 @@ class icms_data_comment_Handler extends icms_ipf_Handler {
 	 * @param   int     $limit      Max num of comments to retrieve
 	 * @param   int     $start      Start offset
 	 *
-	 * @return  array   Array of {@link icms_data_comment_Object} objects
+	 * @return  \icms_data_comment_Object[]
 	 */
 	public function getByItemId($module_id, $item_id, $order = null, $status = null, $limit = null, $start = 0) {
 		$criteria = new icms_db_criteria_Compo(new icms_db_criteria_Item('com_modid', (int) $module_id));
@@ -101,7 +105,7 @@ class icms_data_comment_Handler extends icms_ipf_Handler {
 	 * @param   int     $item_id    Item ID
 	 * @param   int     $status     Status of the comment
 	 *
-	 * @return  array   Array of {@link icms_data_comment_Object} objects
+	 * @return  \icms_data_comment_Object[]
 	 */
 	public function getCountByItemId($module_id, $item_id, $status = null) {
 		$criteria = new icms_db_criteria_Compo(new icms_db_criteria_Item('com_modid', (int) $module_id));
@@ -113,14 +117,14 @@ class icms_data_comment_Handler extends icms_ipf_Handler {
 	}
 
 	/**
-	 * Get the top {@link icms_data_comment_Object}s
+	 * Get the top comments
 	 *
 	 * @param   int     $module_id
 	 * @param   int     $item_id
 	 * @param   strint  $order
 	 * @param   int     $status
 	 *
-	 * @return  array   Array of {@link icms_data_comment_Object} objects
+	 * @return  \icms_data_comment_Object[]
 	 */
 	public function getTopComments($module_id, $item_id, $order, $status = null) {
 		$criteria = new icms_db_criteria_Compo(new icms_db_criteria_Item('com_modid', (int) $module_id));
@@ -140,7 +144,7 @@ class icms_data_comment_Handler extends icms_ipf_Handler {
 	 * @param   int     $comment_id
 	 * @param   int     $status
 	 *
-	 * @return  array   Array of {@link icms_data_comment_Object} objects
+	 * @return \icms_data_comment_Object[]
 	 */
 	public function getThread($comment_rootid, $comment_id, $status = null) {
 		$criteria = new icms_db_criteria_Compo(new icms_db_criteria_Item('com_rootid', (int) $comment_rootid));
@@ -154,7 +158,7 @@ class icms_data_comment_Handler extends icms_ipf_Handler {
 	/**
 	 * Update
 	 *
-	 * @param   object  &$comment       {@link icms_data_comment_Object} object
+	 * @param   \icms_data_comment_Object  &$comment      Comment object
 	 * @param   string  $field_name     Name of the field
 	 * @param   mixed   $field_value    Value to write
 	 *
@@ -175,29 +179,5 @@ class icms_data_comment_Handler extends icms_ipf_Handler {
 	public function deleteByModule($module_id) {
 		return $this->deleteAll(new icms_db_criteria_Item('com_modid', (int) $module_id));
 	}
-
-	/**
-	 * Change a value in multiple comments
-	 *
-	 * @param   string  $fieldname  Name of the field
-	 * @param   string  $fieldvalue Value to write
-	 * @param   object  $criteria   {@link icms_db_criteria_Element}
-	 *
-	 * @return  bool
-	 */
-	/*
-	 function updateAll($fieldname, $fieldvalue, $criteria = null)
-	 {
-	 $set_clause = is_numeric($fieldvalue) ? $filedname.' = '.$fieldvalue : $filedname.' = '.$this->db->quoteString($fieldvalue);
-	 $sql = 'UPDATE '.$this->db->prefix('xoopscomments').' SET '.$set_clause;
-	 if (isset($criteria) && is_subclass_of($criteria, 'icms_db_criteria_Element')) {
-	 $sql .= ' '.$criteria->renderWhere();
-	 }
-	 if (!$result = $this->db->query($sql)) {
-	 return false;
-	 }
-	 return true;
-	 }
-	 */
 }
 

--- a/libraries/icms/data/comment/Renderer.php
+++ b/libraries/icms/data/comment/Renderer.php
@@ -71,10 +71,11 @@ class icms_data_comment_Renderer {
 	/**
 	 * Access the only instance of this class
 	 *
-	 * @param   object  $tpl        reference to a {@link Smarty} object
-	 * @param   boolean $use_icons
-	 * @param   boolean $do_iconcheck
-	 * @return
+	 * @param \Smarty $tpl reference to a Smarty object
+	 * @param boolean $use_icons
+	 * @param boolean $do_iconcheck
+	 *
+	 * @return icms_data_comment_Renderer
 	 */
 	static function &instance(&$tpl, $use_icons = true, $do_iconcheck = false) {
 		static $instance;
@@ -87,7 +88,7 @@ class icms_data_comment_Renderer {
 	/**
 	 * Accessor
 	 *
-	 * @param   object  &$comments_arr  array of {@link XoopsComment} objects
+	 * @param   \icms_data_comment_Object[]  &$comments_arr  array of comments
 	 */
 	public function setComments(&$comments_arr) {
 		if (isset($this->_comments)) {

--- a/libraries/icms/data/notification/Handler.php
+++ b/libraries/icms/data/notification/Handler.php
@@ -167,7 +167,7 @@ class icms_data_notification_Handler extends icms_ipf_Handler {
 	 *
 	 * @param  int  $user_id  ID of the user
 	 *
-	 * @return array  Array of {@link icms_data_notification_Object} objects
+	 * @return \icms_data_notification_Object[]
 	 */
 	public function getByUser($user_id) {
 		$criteria = new icms_db_criteria_Item('not_uid', $user_id);
@@ -181,7 +181,7 @@ class icms_data_notification_Handler extends icms_ipf_Handler {
 	 * @param  int      $item_id  ID of the subscribed items
 	 * @param  int      $module_id  ID of the module of the subscribed items
 	 * @param  int      $user_id  ID of the user of the subscribed items
-	 * @return array    Array of {@link icms_data_notification_Object} objects
+	 * @return \icms_data_notification_Object[]
 	 */
 	public function getSubscribedEvents($category, $item_id, $module_id, $user_id) {
 		$criteria = new icms_db_criteria_Compo();
@@ -208,7 +208,7 @@ class icms_data_notification_Handler extends icms_ipf_Handler {
 	 * @param   string  $order      Sort order
 	 * @param   string  $status     status
 	 *
-	 * @return  array   Array of {@link icms_data_notification_Object} objects
+	 * @return  \icms_data_notification_Object[]
 	 */
 	public function getByItemId($module_id, $item_id, $order = null, $status = null) {
 		$criteria = new icms_db_criteria_Compo(new icms_db_criteria_Item('com_modid', (int) $module_id));
@@ -474,7 +474,7 @@ class icms_data_notification_Handler extends icms_ipf_Handler {
 	/**
 	 * Update
 	 *
-	 * @param   object  &$notification  {@link icms_data_notification_Object} object
+	 * @param   \icms_data_notification_Object  &$notification  Notification object
 	 * @param   string  $field_name     Name of the field
 	 * @param   mixed   $field_value    Value to write
 	 *

--- a/libraries/icms/data/privmessage/Handler.php
+++ b/libraries/icms/data/privmessage/Handler.php
@@ -52,7 +52,7 @@ class icms_data_privmessage_Handler extends icms_ipf_Handler {
 
 	/**
 	 * Mark a message as read
-	 * @param 	object 	$pm 	{@link icms_data_privmessage_Object} object
+	 * @param 	\icms_data_privmessage_Object 	$pm 	Private message
 	 * @return 	bool
 	 */
 	public function setRead(&$pm) {

--- a/libraries/icms/db/IDatabase.php
+++ b/libraries/icms/db/IDatabase.php
@@ -8,10 +8,10 @@
  */
 interface icms_db_legacy_IDatabase {
 	/**
-	 * assign a {@link icms_core_Logger} object to the database
+	 * assign a logger to the database
 	 *
 	 * @see icms_core_Logger
-	 * @param object $logger reference to a {@link icms_core_Logger} object
+	 * @param \icms_core_Logger $logger reference to a logger object
 	 */
 	public function setLogger($logger);
 	/**

--- a/libraries/icms/db/criteria/Compo.php
+++ b/libraries/icms/db/criteria/Compo.php
@@ -43,7 +43,7 @@
  */
 
 /**
- * Collection of multiple {@link icms_db_criteria_Element}s
+ * Collection of multiple criteria elements
  *
  * @package	ICMS\Database\Criteria
  * @author	Kazumi Ono	<onokazu@xoops.org>
@@ -53,7 +53,8 @@ class icms_db_criteria_Compo extends icms_db_criteria_Element {
 
 	/**
 	 * The elements of the collection
-	 * @var	array   Array of {@link icms_db_criteria_Element} objects
+	 *
+	 * @var	\icms_db_criteria_Element[] $criteriaElements
 	 */
 	public $criteriaElements = array();
 

--- a/libraries/icms/db/legacy/Factory.php
+++ b/libraries/icms/db/legacy/Factory.php
@@ -83,7 +83,7 @@ class icms_db_legacy_Factory extends icms_db_Factory {
 	 *
 	 * @copyright	http://www.impresscms.org/ The ImpressCMS Project
 	 *
-	 * @return	object  @link icms_db_legacy_updater_Handler
+	 * @return	\icms_db_legacy_updater_Handler  Updater handler
 	 * @static
 	 */
 	static public function getDatabaseUpdater() {

--- a/libraries/icms/db/legacy/updater/Handler.php
+++ b/libraries/icms/db/legacy/updater/Handler.php
@@ -503,12 +503,12 @@ class icms_db_legacy_updater_Handler {
 	/**
 	 * Use to update a table
 	 *
-	 * @param object $table {@link icms_db_legacy_updater_Table} that will be updated
+	 * @param \icms_db_legacy_updater_Table $table Table that will be updated
 	 * @param bool $force force the query even in a GET process
 	 *
 	 * @see icms_db_legacy_updater_Table
 	 *
-	 * @return bool true if success, false if an error occured
+	 * @return bool true if success, false if an error occurred
 	 */
 	function updateTable($table, $force = false)
 	{
@@ -549,7 +549,7 @@ class icms_db_legacy_updater_Handler {
 	/**
 	 * Update the DBVersion of a module
 	 *
-	 * @param int $newDVersion new database version
+	 * @param int $newDBVersion new database version
 	 * @param string $dirname dirname of the module
 	 *
 	 * @return bool TRUE if success FALSE if not

--- a/libraries/icms/db/legacy/updater/Table.php
+++ b/libraries/icms/db/legacy/updater/Table.php
@@ -75,7 +75,7 @@ class icms_db_legacy_updater_Table {
 	/**
 	 * xoopsDB database object
 	 *
-	 * @var @link XoopsDatabase object
+	 * @var \icms_db_legacy_IDatabase
 	 */
 	var $db;
 
@@ -240,12 +240,10 @@ class icms_db_legacy_updater_Table {
 	/**
 	 * Add item to be updated on the the table via the UpdateAll method
 	 *
-	 * @param   string  $fieldname  Name of the field
-	 * @param   string  $fieldvalue Value to write
-	 * @param   object  $criteria   {@link icms_db_criteria_Element}
-	 * @param 	bool	$fieldvalueIsOperation TRUE if fieldvalue is an operation, for example, conf_order+1
-	 *
-	 * @return  bool
+	 * @param string $fieldname Name of the field
+	 * @param string $fieldvalue Value to write
+	 * @param \icms_db_criteria_Element $criteria Criteria
+	 * @param bool $fieldvalueIsOperation TRUE if fieldvalue is an operation, for example, conf_order+1
 	 */
 	function addUpdateAll($fieldname, $fieldvalue, $criteria, $fieldvalueIsOperation) {
 		$item['fieldname'] = $fieldname;
@@ -258,11 +256,9 @@ class icms_db_legacy_updater_Table {
 	/**
 	 * Add item to be updated on the the table via the UpdateAll method
 	 *
-	 * @param   string  $fieldname  Name of the field
-	 * @param   string  $fieldvalue Value to write
-	 * @param   object  $criteria   {@link icms_db_criteria_Element}
+	 * @param \icms_db_criteria_Element $criteria Criteria
 	 *
-	 * @return  bool
+	 * @return void
 	 */
 	function addDeleteAll($criteria) {
 		$item['criteria'] = $criteria;
@@ -453,7 +449,7 @@ class icms_db_legacy_updater_Table {
 	 *
 	 * @param   string  $fieldname  Name of the field
 	 * @param   string  $fieldvalue Value to write
-	 * @param   object  $criteria   {@link icms_db_criteria_Element}
+	 * @param \icms_db_criteria_Element $criteria Criteria
 	 *
 	 * @return  bool
 	 */
@@ -504,7 +500,7 @@ class icms_db_legacy_updater_Table {
 	/**
 	 * delete all objects meeting the conditions
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element} with conditions to meet
+	 * @param \icms_db_criteria_Element $criteria Criteria with conditions to meet
 	 * @return bool
 	 */
 

--- a/libraries/icms/form/Base.php
+++ b/libraries/icms/form/Base.php
@@ -70,8 +70,9 @@ abstract class icms_form_Base {
 	private $_title;
 
 	/**
-	 * array of {@link icms_form_Element} objects
-	 * @var  array
+	 * Elements of form
+	 *
+	 * @var  icms_form_Element[]
 	 */
 	protected $_elements = array();
 
@@ -155,7 +156,7 @@ abstract class icms_form_Base {
 	/**
 	 * Add an element to the form
 	 *
-	 * @param	object  &$formElement   reference to a {@link icms_form_Element}
+	 * @param	icms_form_Element  &$formElement   Form element
 	 * @param	bool    $required       is this a "required" element?
 	 */
 	public function addElement(&$formElement, $required = false) {
@@ -182,7 +183,7 @@ abstract class icms_form_Base {
 	 * get an array of forms elements
 	 *
 	 * @param	  bool	  get elements recursively?
-	 * @return	array   array of {@link icms_form_Element}s
+	 * @return	icms_form_Element[]
 	 */
 	public function &getElements($recurse = false) {
 		if (!$recurse) {
@@ -224,10 +225,11 @@ abstract class icms_form_Base {
 	}
 
 	/**
-	 * get a reference to a {@link icms_form_Element} object by its "name"
+	 * get a reference form object by its "name"
 	 *
-	 * @param  string  $name	"name" attribute assigned to a {@link icms_form_Element}
-	 * @return mixed  reference to a {@link icms_form_Element}, false if not found
+	 * @param  string  $name	"name" attribute assigned to a form element
+	 *
+	 * @return icms_form_Element|false
 	 */
 	public function &getElementByName($name) {
 		$elements = $this->getElements(true);
@@ -332,7 +334,7 @@ abstract class icms_form_Base {
 	/**
 	 * make an element "required"
 	 *
-	 * @param	object  &$formElement    reference to a {@link icms_form_Element}
+	 * @param	icms_form_Element  &$formElement   Form element
 	 */
 	public function setRequired(&$formElement) {
 		$this->_required[] = & $formElement;
@@ -341,7 +343,7 @@ abstract class icms_form_Base {
 	/**
 	 * get an array of "required" form elements
 	 *
-	 * @return	array   array of {@link icms_form_Element}s
+	 * @return	icms_form_Element[]
 	 */
 	public function &getRequired() {
 		return $this->_required;
@@ -418,7 +420,8 @@ abstract class icms_form_Base {
 	/**
 	 * assign to smarty form template instead of displaying directly
 	 *
-	 * @param	object  &$tpl    reference to a {@link Smarty} object
+	 * @param	Smarty  &$tpl    Smarty template
+	 *
 	 * @see     Smarty
 	 */
 	public function assign(&$tpl) {

--- a/libraries/icms/form/elements/Captcha.php
+++ b/libraries/icms/form/elements/Captcha.php
@@ -62,9 +62,11 @@ class icms_form_elements_Captcha extends icms_form_Element {
 
 	/**
 	 * Sets the Config
+	 *
 	 * @param   string $name Config Name
 	 * @param   string $val Config Value
-	 * @return  object reference to the icms_form_elements_captcha_Object Object (@link icms_form_elements_captcha_Object)
+	 *
+	 * @return  \icms_form_elements_captcha_Object
 	 */
 	public function setConfig($name, $val) {
 		return $this->_captchaHandler->setConfig($name, $val);

--- a/libraries/icms/form/elements/Tray.php
+++ b/libraries/icms/form/elements/Tray.php
@@ -96,7 +96,8 @@ class icms_form_elements_Tray extends icms_form_Element {
 	/**
 	 * Add an element to the group
 	 *
-	 * @param	object  &$element    {@link icms_form_Element} to add
+	 * @param \icms_form_Element  &$formElement Element to add
+	 * @param bool $required Is required?
 	 */
 	public function addElement(&$formElement, $required = false) {
 		$this->_elements[] = & $formElement;
@@ -117,7 +118,7 @@ class icms_form_elements_Tray extends icms_form_Element {
 	/**
 	 * get an array of "required" form elements
 	 *
-	 * @return	array   array of {@link icms_form_Element}s
+	 * @return	\icms_form_Element[]
 	 */
 	public function &getRequired() {
 		return $this->_required;
@@ -127,7 +128,7 @@ class icms_form_elements_Tray extends icms_form_Element {
 	 * Get an array of the elements in this group
 	 *
 	 * @param	bool	$recurse	get elements recursively?
-	 * @return  array   Array of {@link icms_form_Element} objects.
+	 * @return  \icms_form_Element[]
 	 */
 	public function &getElements($recurse = false) {
 		if (!$recurse) {

--- a/libraries/icms/form/elements/captcha/Text.php
+++ b/libraries/icms/form/elements/captcha/Text.php
@@ -25,7 +25,8 @@ class icms_form_elements_captcha_Text {
 
 	/**
 	 * Creates icms_form_elements_captcha_Text object
-	 * @return object	reference to icms_form_elements_captcha_Text (@link icms_form_elements_captcha_Text) Object
+	 *
+	 * @return \icms_form_elements_captcha_Text
 	 */
 	public function &instance() {
 		static $instance;

--- a/libraries/icms/form/elements/select/Matchoption.php
+++ b/libraries/icms/form/elements/select/Matchoption.php
@@ -48,8 +48,8 @@ class icms_form_elements_select_Matchoption extends icms_form_elements_Select {
 	 * @param	string	$caption
 	 * @param	string	$name
 	 * @param	mixed	$value	Pre-selected value (or array of them).
-	 * 							Legal values are {@link XOOPS_MATCH_START}, {@link XOOPS_MATCH_END},
-	 * 							{@link XOOPS_MATCH_EQUAL}, and {@link XOOPS_MATCH_CONTAIN}
+	 * 							Legal values are XOOPS_MATCH_START, XOOPS_MATCH_END,
+	 * 							XOOPS_MATCH_EQUAL, and XOOPS_MATCH_CONTAIN
 	 * @param	int		$size	Number of rows. "1" makes a drop-down-list
 	 */
 	public function __construct($caption, $name, $value = null, $size = 1) {

--- a/libraries/icms/image/Handler.php
+++ b/libraries/icms/image/Handler.php
@@ -96,9 +96,9 @@ class icms_image_Handler extends \icms_ipf_Handler {
 		}
 
 	/**
-	 * Load {@link icms_image_Object}s from the database
+	 * Load image from the database
 	 *
-	 * @param null|icms_db_criteria_Item $criteria {@link icms_db_criteria_Element}
+	 * @param null|icms_db_criteria_Item $criteria Criteria
 	 * @param bool $id_as_key Use the ID as key into the array
 	 * @param bool $getbinary Get binary image?
 	 * @param bool|string $sql  Extra sql

--- a/libraries/icms/image/category/Handler.php
+++ b/libraries/icms/image/category/Handler.php
@@ -57,7 +57,7 @@ class icms_image_category_Handler extends \icms_ipf_Handler {
 	/**
 	 * Retrieve array of {@link icms_image_category_Object}s meeting certain conditions
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element} with conditions for the image categories
+	 * @param \icms_db_criteria_Element $criteria Criteria with conditions for the image categories
 	 * @param bool $id_as_key should the image category's imgcat_id be the key for the returned array?
 	 *
 	 * @return array {@link icms_image_category_Object}s matching the conditions

--- a/libraries/icms/image/category/Handler.php
+++ b/libraries/icms/image/category/Handler.php
@@ -55,12 +55,12 @@ class icms_image_category_Handler extends \icms_ipf_Handler {
 		}
 
 	/**
-	 * Retrieve array of {@link icms_image_category_Object}s meeting certain conditions
+	 * Retrieve array meeting certain conditions
 	 *
 	 * @param \icms_db_criteria_Element $criteria Criteria with conditions for the image categories
 	 * @param bool $id_as_key should the image category's imgcat_id be the key for the returned array?
 	 *
-	 * @return array {@link icms_image_category_Object}s matching the conditions
+	 * @return icms_image_category_Object[]
 	 */
 	public function getObjects($criteria = null, $id_as_key = false, $as_object = true, $sql = false, $debug = false) {
 			$this->generalSQL = 'SELECT DISTINCT c.* FROM ' . $this->table . ' c LEFT JOIN '
@@ -78,11 +78,11 @@ class icms_image_category_Handler extends \icms_ipf_Handler {
 	}
 
 	/**
-	 * get number of {@link icms_image_category_Object}s matching certain conditions
+	 * Get number matching certain conditions
 	 *
-	 * @param string $criteria conditions to match
+	 * @param null|icms_db_criteria_Element $criteria conditions to match
 	 *
-	 * @return int number of {@link icms_image_category_Object}s matching the conditions
+	 * @return int
 	 */
 	public function getCount($criteria = null) {
 			$this->generalSQL = 'SELECT COUNT(*) FROM ' . $this->table . ' i LEFT JOIN '
@@ -100,14 +100,14 @@ class icms_image_category_Handler extends \icms_ipf_Handler {
 	}
 
 		/**
-		 * Get a list of {@link icms_image_category_Object}s matching certain conditions
+		 * Get a list matching certain conditions
 		 *
 		 * @param array         $groups         Groups list
 		 * @param string        $perm           Permission name
 		 * @param null|integer  $display        Do we need to list only visible or hidden items?
 		 * @param string|null   $storetype      How to store images of this category?
 		 *
-		 * @return array                        array of {@link icms_image_category_Object}s matching the conditions
+		 * @return icms_image_category_Object[]
 		 */
 	public function getList($groups = array(), $perm = 'imgcat_read', $display = null, $storetype = null) {
 		$criteria = new icms_db_criteria_Compo();

--- a/libraries/icms/image/category/Object.php
+++ b/libraries/icms/image/category/Object.php
@@ -37,7 +37,7 @@
 /**
  * An image category
  *
- * These categories are managed through a {@link icms_image_category_Handler} object
+ * These categories are managed through a icms_image_category_Handler object
  *
  * @author	Kazumi Ono	<onokazu@xoops.org>
  * @copyright	Copyright (c) 2000 XOOPS.org

--- a/libraries/icms/image/set/Handler.php
+++ b/libraries/icms/image/set/Handler.php
@@ -75,12 +75,12 @@ class icms_image_set_Handler extends \icms_ipf_Handler {
 		}
 
 	/**
-	 * Retrieve array of {@link icms_image_set_Object}s meeting certain conditions
+	 * Retrieve array of images meeting certain conditions
 	 *
-	 * @param object $criteria {@link CriteriaElement} with conditions for the imagesets
+	 * @param \icms_db_criteria_Element $criteria Criteria with conditions for the imagesets
 	 * @param bool $id_as_key should the imageset's imgset_id be the key for the returned array?
 	 *
-	 * @return array {@link icms_image_set_Object}s matching the conditions
+	 * @return \icms_image_set_Object[]
 	 */
 	public function &getObjects($criteria = null, $id_as_key = false) {
 		$ret = array();
@@ -108,7 +108,7 @@ class icms_image_set_Handler extends \icms_ipf_Handler {
 	}
 
 	/**
-	 * Links a {@link icms_image_set_Object} to a themeset (tplset)
+	 * Links a image set to a themeset (tplset)
 	 * @param int $imgset_id image set id to link
 	 * @param int $tplset_name theme set to link
 	 *
@@ -132,7 +132,7 @@ class icms_image_set_Handler extends \icms_ipf_Handler {
 	}
 
 	/**
-	 * Unlinks a {@link icms_image_set_Object} from a themeset (tplset)
+	 * Unlinks a image set from a themeset (tplset)
 	 *
 	 * @param int $imgset_id image set id to unlink
 	 * @param int $tplset_name theme set to unlink
@@ -154,11 +154,12 @@ class icms_image_set_Handler extends \icms_ipf_Handler {
 	}
 
 	/**
-	 * Get a list of {@link icms_image_set_Object}s matching certain conditions
+	 * Get a list of image set objects matching certain conditions
 	 *
 	 * @param int $refid conditions to match
 	 * @param int $tplset conditions to match
-	 * @return array array of {@link icms_image_set_Object}s matching the conditions
+	 *
+	 * @return \icms_image_set_Object[]
 	 * */
 	public function getList($refid = null, $tplset = null) {
 		$criteria = new CriteriaCompo();

--- a/libraries/icms/image/set/Object.php
+++ b/libraries/icms/image/set/Object.php
@@ -43,7 +43,7 @@
 /**
  * An imageset
  *
- * These sets are managed through a {@link icms_image_set_Handler} object
+ * These sets are managed through a icms_image_set_Handler object
  *
  * @author	    Kazumi Ono	<onokazu@xoops.org>
  * @copyright       copyright (c) 2000-2003 XOOPS.org

--- a/libraries/icms/ipf/Controller.php
+++ b/libraries/icms/ipf/Controller.php
@@ -431,7 +431,7 @@ class icms_ipf_Controller {
 	}
 
 	/**
-	 * Retrieve the object admin side link for a {@link icms_ipf_view_Single} page
+	 * Retrieve the object admin side link for a page
 	 *
 	 * @param	object	$icmsObj	reference to the object from which we want the user side link
 	 * @param	bool	$onlyUrl	whether or not to return a simple URL or a full <a> link

--- a/libraries/icms/ipf/Handler.php
+++ b/libraries/icms/ipf/Handler.php
@@ -347,7 +347,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	 *
 	 * @deprecated Use getObjects() instead
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element} conditions to be met
+	 * @param \icms_db_criteria_Element $criteria Criteria conditions to be met
 	 * @param bool $id_as_key use the ID as key for the array?
 	 * @param bool $as_object return an array of objects?
 	 *
@@ -362,7 +362,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	/**
 	 * retrieve objects from the database
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element} conditions to be met
+	 * @param \icms_db_criteria_Element $criteria Criteria conditions to be met
 	 * @param bool $id_as_key use the ID as key for the array?
 	 * @param bool $as_object return an array of objects?
 	 *
@@ -751,7 +751,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	/**
 	 * Retrieve a list of objects as arrays - DON'T USE WITH JOINT KEYS
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element} conditions to be met
+	 * @param \icms_db_criteria_Element $criteria Criteria conditions to be met
 	 * @param int   $limit      Max number of objects to fetch
 	 * @param int   $start      Which record to start at
 	 *
@@ -766,7 +766,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	 *
 	 * @param string $keyName  Key name
 	 * @param string $keyValue Key value
-	 * @param object $criteria {@link icms_db_criteria_Element} conditions to be met
+	 * @param \icms_db_criteria_Element $criteria Criteria conditions to be met
 	 * @param int   $limit     Max number of objects to fetch
 	 * @param int   $start     Which record to start at
 	 * @param bool $debug Debug mode?
@@ -1175,7 +1175,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	 * query the database with the constructed $criteria object
 	 *
 	 * @param string $sql The SQL Query
-	 * @param object $criteria {@link icms_db_criteria_Element} conditions to be met
+	 * @param \icms_db_criteria_Element $criteria Criteria conditions to be met
 	 * @param bool $force Force the query?
 	 * @param bool $debug Turn Debug on?
 	 *
@@ -1217,7 +1217,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	/**
 	 * count objects matching a condition
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element} to match
+	 * @param \icms_db_criteria_Element $criteria Criteria to match
 	 * @return int count of objects
 	 */
 	public function getCount($criteria = null) {
@@ -1294,7 +1294,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	 *
 	 * @param   string  $fieldname  Name of the field
 	 * @param   string  $fieldvalue Value to write
-	 * @param   object  $criteria   {@link icms_db_criteria_Element}
+	 * @param \icms_db_criteria_Element $criteria Criteria
 	 *
 	 * @return  bool
 	 * */
@@ -1325,7 +1325,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	/**
 	 * delete all objects meeting the conditions
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element} with conditions to meet
+	 * @param \icms_db_criteria_Element $criteria Criteria with conditions to meet
 	 * @param bool $quick Do not load object on deletion?
 	 *
 	 * @return bool

--- a/libraries/icms/ipf/Handler.php
+++ b/libraries/icms/ipf/Handler.php
@@ -39,7 +39,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	 */
 	public $_itemname = '';
 	/**
-	 * Name of the table use to store this {@link icms_ipf_Object}
+	 * Name of the table use to store objects linked with this handler
 	 *
 	 * Note that the name of the table needs to be free of the database prefix.
 	 * For example "smartsection_categories"
@@ -47,14 +47,14 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	 */
 	public $table = '';
 	/**
-	 * Name of the table key that uniquely identify each {@link icms_ipf_Object}
+	 * Name of the table key that uniquely identify each object
 	 *
 	 * For example : "categoryid"
 	 * @var string
 	 */
 	public $keyName = '';
 	/**
-	 * Name of the class derived from {@link icms_ipf_Object} and which this handler is handling
+	 * Name of the class derived from object and which this handler is handling
 	 *
 	 * Note that this string needs to be lowercase
 	 *
@@ -63,7 +63,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	 */
 	public $className = '';
 	/**
-	 * Name of the field which properly identify the {@link icms_ipf_Object}
+	 * Name of the field which properly identify the object
 	 *
 	 * For example : "name" (this will be the category's name)
 	 * @var string
@@ -77,7 +77,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	 */
 	public $summaryName = '';
 	/**
-	 * Page name use to basically manage and display the {@link icms_ipf_Object}
+	 * Page name use to basically manage and display the object
 	 *
 	 * This page needs to be the same in user side and admin side
 	 *
@@ -89,7 +89,7 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	 */
 	public $_page = '';
 	/**
-	 * Full path of the module using this {@link icms_ipf_Object}
+	 * Full path of the module using this object
 	 *
 	 * <code>ICMS_URL . "/modules/smartsection/"</code>
 	 * @todo this could probably be automatically deducted from the class name as it is always prefixed with the module name
@@ -204,15 +204,14 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	/**
 	 * Constructor - called from child classes
 	 *
-	 * @param object $db Database object {@link XoopsDatabase}
+	 * @param icms_db_IConnection $db Database object
 	 * @param string $itemname Object to be managed
-	 * @param string $keyname Name of the table key that uniquely identify each {@link icms_ipf_Object}
-	 * @param string $idenfierName Name of the field which properly identify the {@link icms_ipf_Object}
+	 * @param string $keyname Name of the table key that uniquely identify each object
+	 * @param string $idenfierName Name of the field which properly identify the object
 	 * @param string $summaryName Name of the field which will be use as a summary for the object
 	 * @param string $modulename Directory name of the module controlling this object
-	 * @param string/null $table    Table which will be used for this object
-	 * @param bool/object $cacheHandler IDs for caching
-	 * @return object
+	 * @param null|string $table Table to use for this handler
+	 * @param bool $cacheHandler Cache handler
 	 */
 	public function __construct(&$db, $itemname, $keyname, $idenfierName, $summaryName, $modulename = null, $table = null, $cacheHandler = false) {
 
@@ -643,13 +642,14 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	}
 
 	/**
-	 * retrieve a {@link icms_ipf_Object}
+	 * retrieve object
 	 *
 	 * @deprecated Use get() instead
 	 *
-	 * @param mixed $id ID of the object - or array of ids for joint keys. Joint keys MUST be given in the same order as in the constructor
+	 * @param string|float|int $id ID of the object - or array of ids for joint keys. Joint keys MUST be given in the same order as in the constructor
 	 * @param bool $as_object whether to return an object or an array
-	 * @return mixed reference to the {@link icms_ipf_Object}, FALSE if failed
+	 *
+	 * @return icms_ipf_Object|false
 	 */
 	public function &getD($id, $as_object = true)
 	{
@@ -659,11 +659,12 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	}
 
 	/**
-	 * retrieve a {@link icms_ipf_Object}
+	 * retrieve a object by id
 	 *
-	 * @param mixed $id ID of the object - or array of ids for joint keys. Joint keys MUST be given in the same order as in the constructor
+	 * @param string|int|float $id ID of the object - or array of ids for joint keys. Joint keys MUST be given in the same order as in the constructor
 	 * @param bool $as_object whether to return an object or an array
-	 * @return mixed reference to the {@link icms_ipf_Object}, FALSE if failed
+	 *
+	 * @return icms_ipf_Object|false
 	 */
 	public function &get($id, $as_object = true, $debug = false, $criteria = false)
 	{
@@ -711,11 +712,11 @@ class icms_ipf_Handler extends icms_core_ObjectHandler {
 	}
 
 	/**
-	 * create a new {@link icms_ipf_Object}
+	 * create a new object
 	 *
 	 * @param bool $isNew Flag the new objects as "new"?
 	 *
-	 * @return object {@link icms_ipf_Object}
+	 * @return icms_ipf_Object
 	 */
 	public function &create($isNew = true)
 	{

--- a/libraries/icms/ipf/Object.php
+++ b/libraries/icms/ipf/Object.php
@@ -116,31 +116,22 @@ class icms_ipf_Object extends icms_core_Object {
 	}
 
 	/**
+	 * Inits variable
 	 *
-	 * @param string $key
-	 *        key of this field. This needs to be the name of the field in the related database table
-	 * @param int $data_type
-	 *        set to one of self::DTYPE_XXX constants
-	 * @param mixed $value
-	 *        default value of this variable
-	 * @param bool $required
-	 *        set to TRUE if this variable needs to have a value set before storing the object in the table
-	 * @param int $maxlength
-	 *        maximum length of this variable, for self::DTYPE_STRING and self::DTYPE_INTEGER types only
-	 * @param string $options
-	 *        does this data have any select options?
-	 * @param bool $multilingual
-	 *        is this field needs to support multilingual features (NOT YET IMPLEMENTED...)
-	 * @param string $form_caption
-	 *        caption of this variable in a {@link icms_ipf_form_Base} and title of a column in a {@link icms_ipf_ObjectTable}
-	 * @param string $form_dsc
-	 *        description of this variable in a {@link icms_ipf_form_Base}
-	 * @param bool $sortby
-	 *        set to TRUE to make this field used to sort objects in icms_ipf_ObjectTable
-	 * @param bool $persistent
-	 *        set to FALSE if this field is not to be saved in the database
-	 * @param bool $displayOnForm
-	 *        to be displayed on the form or not
+	 * @param string $key key of this field. This needs to be the name of the field in the related database table
+	 * @param int $data_type set to one of self::DTYPE_XXX constants
+	 * @param mixed $value default value of this variable
+	 * @param bool $required set to TRUE if this variable needs to have a value set before storing the object in the table
+	 * @param int $maxlength maximum length of this variable, for self::DTYPE_STRING and self::DTYPE_INTEGER types only
+	 * @param string $options does this data have any select options?
+	 * @param bool $multilingual is this field needs to support multilingual features (NOT YET IMPLEMENTED...)
+	 * @param string $form_caption caption of this variable in a icms_ipf_form_Base and title of a column in a icms_ipf_ObjectTable
+	 * @param string $form_dsc description of this variable in a icms_ipf_form_Base
+	 * @param bool $sortby set to TRUE to make this field used to sort objects in icms_ipf_ObjectTable
+	 * @param bool $persistent set to FALSE if this field is not to be saved in the database
+	 * @param bool $displayOnForm to be displayed on the form or not
+	 *
+	 * @return bool
 	 */
 	public function initVar($key, $data_type, $value = null, $required = false, $maxlength = null, $options = '', $multilingual = false, $form_caption = '', $form_dsc = '', $sortby = false, $persistent = true, $displayOnForm = true) {
 		// url_ is reserved for files.
@@ -251,18 +242,12 @@ class icms_ipf_Object extends icms_core_Object {
 	 *
 	 * @deprecated Use initVar instead
 	 *
-	 * @param string $key
-	 *        key of this field. This needs to be the name of the field in the related database table
-	 * @param int $data_type
-	 *        set to one of XOBJ_DTYPE_XXX constants (set to self::DTYPE_DEP_OTHER if no data type ckecking nor text sanitizing is required)
-	 * @param bool $required
-	 *        set to TRUE if this variable needs to have a value set before storing the object in the table
-	 * @param string $form_caption
-	 *        caption of this variable in a {@link icms_ipf_form_Base} and title of a column in a {@link icms_ipf_ObjectTable}
-	 * @param string $form_dsc
-	 *        description of this variable in a {@link icms_ipf_form_Base}
-	 * @param mixed $value
-	 *        default value of this variable
+	 * @param string $key key of this field. This needs to be the name of the field in the related database table
+	 * @param int $data_type set to one of XOBJ_DTYPE_XXX constants (set to self::DTYPE_DEP_OTHER if no data type ckecking nor text sanitizing is required)
+	 * @param bool $required set to TRUE if this variable needs to have a value set before storing the object in the table
+	 * @param string $form_caption caption of this variable in a icms_ipf_form_Base and title of a column in a icms_ipf_ObjectTable
+	 * @param string $form_dsc description of this variable in a icms_ipf_form_Base
+	 * @param mixed $value default value of this variable
 	 */
 	public function quickInitVar($key, $data_type, $required = false, $form_caption = '', $form_dsc = '', $value = null) {
 		trigger_error('Use enableUpload() instead', E_USER_DEPRECATED);
@@ -458,7 +443,14 @@ class icms_ipf_Object extends icms_core_Object {
 	/**
 	 * Create the form for this object
 	 *
-	 * @return a {@link SmartobjectForm} object for this object
+	 * @param string $form_caption Form caption
+	 * @param string $form_name Form name
+	 * @param false|string $form_action Form action
+	 * @param string $submit_button_caption Submit button caption
+	 * @param bool $cancel_js_action Cancels JS action
+	 * @param bool $captcha Needs captcha?
+	 *
+	 * @return icms_ipf_form_Base
 	 *
 	 * @see icms_ipf_ObjectForm::icms_ipf_ObjectForm()
 	 */
@@ -469,7 +461,14 @@ class icms_ipf_Object extends icms_core_Object {
 	/**
 	 * Create the secure form for this object
 	 *
-	 * @return a {@link icms_ipf_form_Secure} object for this object
+	 * @param string $form_caption Form caption
+	 * @param string $form_name Form name
+	 * @param false|string $form_action Form action
+	 * @param string $submit_button_caption Submit button caption
+	 * @param bool $cancel_js_action Cancels JS action
+	 * @param bool $captcha Needs captcha?
+	 *
+	 * @return icms_ipf_form_Secure
 	 *
 	 * @see icms_ipf_ObjectForm::icms_ipf_ObjectForm()
 	 */

--- a/libraries/icms/ipf/Tree.php
+++ b/libraries/icms/ipf/Tree.php
@@ -74,16 +74,16 @@ class icms_ipf_Tree {
 	public $_tree = array();
 
 		/**
-		 * Array of {@link icms_core_Object}s
+		 * Array of objects
 		 *
-		 * @var array
+		 * @var \icms_core_Object[]
 		 */
 	private $_objects = array();
 
 	/**
 	 * Constructor
 	 *
-	 * @param   array	$objectArr  Array of {@link icms_core_Object}s
+	 * @param   \icms_core_Object	$objectArr  Array of objects
 	 * @param   string	$myId       field name of object ID
 	 * @param   string	$parentId   field name of parent object ID
 	 * @param   string	$rootId     field name of root object ID

--- a/libraries/icms/ipf/form/Base.php
+++ b/libraries/icms/ipf/form/Base.php
@@ -26,7 +26,7 @@ class icms_ipf_form_Base extends icms_form_Theme {
 	 * @param	string    $form_caption             the form caption
 	 * @param	string    $form_action              the form action
 	 * @param	string    $form_fields              the form fields
-	 * @param	string    $submit_button_caption    whether to add a caption to the submit button
+	 * @param	string|false    $submit_button_caption    whether to add a caption to the submit button
 	 * @param	bool      $cancel_js_action         whether to invoke a javascript action when cancel button is clicked
 	 * @param	bool      $captcha                  whether to add captcha
 	 */

--- a/libraries/icms/ipf/form/Base.php
+++ b/libraries/icms/ipf/form/Base.php
@@ -81,10 +81,10 @@ class icms_ipf_form_Base extends icms_form_Theme {
 	/**
 	 * Add an element to the form
 	 *
-	 * @param	object  &$formElement   reference to a {@link icms_form_Element}
-	 * @param	string  $key            encrypted key string for the form
-	 * @param	string  $var            some form variables?
-	 * @param	bool    $required       is this a "required" element?
+	 * @param	\icms_form_Element  &$formElement   reference
+	 * @param	string|false  $key            encrypted key string for the form
+	 * @param	string|false  $var            some form variables?
+	 * @param	bool|string    $required       is this a "required" element?
 	 */
 	public function addElement(&$formElement, $key = false, $var = false, $required = 'notset') {
 		if ($key) {
@@ -512,8 +512,7 @@ class icms_ipf_form_Base extends icms_form_Theme {
 	/**
 	 * assign to smarty form template instead of displaying directly
 	 *
-	 * @param	object  &$tpl         reference to a {@link Smarty} object
-	 * @see           Smarty
+	 * @param	\Smarty  &$tpl         reference
 	 * @param	mixed   $smartyName   if smartyName is passed, assign it to the smarty call else assign the name of the form element
 	 */
 	public function assign(&$tpl, $smartyName = false) {

--- a/libraries/icms/ipf/form/Secure.php
+++ b/libraries/icms/ipf/form/Secure.php
@@ -10,13 +10,13 @@
 class icms_ipf_form_Secure extends icms_ipf_form_Base {
 	/**
 	 * Constructor
-	 * Sets all the values / variables for the icms_ipf_form_Base (@link icms_ipf_form_Base) (parent) class
+	 * Sets all the values / variables for the icms_ipf_form_Base (parent) class
 	 * @param	string    &$target                  reference to targetobject (@todo, which object will be passed here?)
 	 * @param	string    $form_name                the form name
 	 * @param	string    $form_caption             the form caption
 	 * @param	string    $form_action              the form action
 	 * @param	string    $form_fields              the form fields
-	 * @param	string    $submit_button_caption    whether to add a caption to the submit button
+	 * @param	string|false    $submit_button_caption    whether to add a caption to the submit button
 	 * @param	bool      $cancel_js_action         whether to invoke a javascript action when cancel button is clicked
 	 * @param	bool      $captcha                  whether to add captcha
 	 */

--- a/libraries/icms/ipf/form/elements/Autocomplete.php
+++ b/libraries/icms/ipf/form/elements/Autocomplete.php
@@ -35,7 +35,7 @@ class icms_ipf_form_elements_Autocomplete extends icms_form_elements_Text {
 
 	/**
 	 * Constructor
-	 * @param	icms_ipf_Object	$object	reference to targetobject (@link icms_ipf_Object)
+	 * @param	icms_ipf_Object	$object	reference to targetobject
 	 * @param	string			$key	the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Blockoptions.php
+++ b/libraries/icms/ipf/form/elements/Blockoptions.php
@@ -12,7 +12,7 @@
 class icms_ipf_form_elements_Blockoptions extends icms_form_elements_Tray {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Checkbox.php
+++ b/libraries/icms/ipf/form/elements/Checkbox.php
@@ -14,7 +14,7 @@ class icms_ipf_form_elements_Checkbox extends icms_form_elements_Checkbox {
 
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Date.php
+++ b/libraries/icms/ipf/form/elements/Date.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Date extends icms_form_elements_Date {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Datetime.php
+++ b/libraries/icms/ipf/form/elements/Datetime.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Datetime extends icms_form_elements_Datetime {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/File.php
+++ b/libraries/icms/ipf/form/elements/File.php
@@ -14,7 +14,7 @@ class icms_ipf_form_elements_File extends icms_form_elements_File {
 
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Fileupload.php
+++ b/libraries/icms/ipf/form/elements/Fileupload.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Fileupload extends icms_ipf_form_elements_Upload {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Image.php
+++ b/libraries/icms/ipf/form/elements/Image.php
@@ -12,7 +12,7 @@
 class icms_ipf_form_elements_Image extends icms_form_elements_Tray {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Language.php
+++ b/libraries/icms/ipf/form/elements/Language.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Language extends icms_form_elements_select_Lang {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Page.php
+++ b/libraries/icms/ipf/form/elements/Page.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Page extends icms_form_elements_Tray {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Parentcategory.php
+++ b/libraries/icms/ipf/form/elements/Parentcategory.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Parentcategory extends icms_form_elements_Select {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Parentcategory.php
+++ b/libraries/icms/ipf/form/elements/Parentcategory.php
@@ -41,7 +41,7 @@ class icms_ipf_form_elements_Parentcategory extends icms_form_elements_Select {
 	/**
 	 * Get options for a category select with hierarchy (recursive)
 	 *
-	 * @param object  $tree         icms_ipf_Tree $tree (@link icms_ipf_Tree)
+	 * @param \icms_ipf_Tree  $tree       Tree instance
 	 * @param string  $fieldName    The fieldname to get the option array for
 	 * @param int     $key          the key to get the optionarray for
 	 * @param string  $prefix_curr  the prefix

--- a/libraries/icms/ipf/form/elements/Passwordtray.php
+++ b/libraries/icms/ipf/form/elements/Passwordtray.php
@@ -13,7 +13,7 @@ class icms_ipf_form_elements_Passwordtray extends icms_form_elements_Tray {
 
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Radio.php
+++ b/libraries/icms/ipf/form/elements/Radio.php
@@ -14,7 +14,7 @@ class icms_ipf_form_elements_Radio extends icms_form_elements_Radio {
 
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Section.php
+++ b/libraries/icms/ipf/form/elements/Section.php
@@ -25,7 +25,7 @@ class icms_ipf_form_elements_Section extends icms_form_Element {
 	/**
 	 * Constructor
 	 *
-	 * @param	icms_ipf_Object	$object	reference to targetobject (@link icms_ipf_Object)
+	 * @param	icms_ipf_Object	$object	reference to targetobject
 	 * @param	string			$key	name of the form section
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Select.php
+++ b/libraries/icms/ipf/form/elements/Select.php
@@ -13,7 +13,7 @@ class icms_ipf_form_elements_Select extends icms_form_elements_Select {
 
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Selectmulti.php
+++ b/libraries/icms/ipf/form/elements/Selectmulti.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Selectmulti extends icms_ipf_form_elements_Select {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Signature.php
+++ b/libraries/icms/ipf/form/elements/Signature.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Signature extends icms_form_elements_Tray {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Source.php
+++ b/libraries/icms/ipf/form/elements/Source.php
@@ -16,7 +16,7 @@ class icms_ipf_form_elements_Source extends icms_form_elements_Textarea {
 
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Text.php
+++ b/libraries/icms/ipf/form/elements/Text.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Text extends icms_form_elements_Text {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Time.php
+++ b/libraries/icms/ipf/form/elements/Time.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Time extends icms_form_elements_Select {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Upload.php
+++ b/libraries/icms/ipf/form/elements/Upload.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Upload extends icms_form_elements_File {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/User.php
+++ b/libraries/icms/ipf/form/elements/User.php
@@ -13,7 +13,7 @@ class icms_ipf_form_elements_User extends icms_form_elements_Select {
 
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/form/elements/Yesno.php
+++ b/libraries/icms/ipf/form/elements/Yesno.php
@@ -11,7 +11,7 @@
 class icms_ipf_form_elements_Yesno extends icms_form_elements_Radioyn {
 	/**
 	 * Constructor
-	 * @param	object    $object   reference to targetobject (@link icms_ipf_Object)
+	 * @param	\icms_ipf_Object    $object   reference to targetobject
 	 * @param	string    $key      the form name
 	 */
 	public function __construct($object, $key) {

--- a/libraries/icms/ipf/view/Table.php
+++ b/libraries/icms/ipf/view/Table.php
@@ -62,12 +62,10 @@ class icms_ipf_view_Table {
 	/**
 	 * Constructor
 	 *
-	 * @param object $objectHandler {@link icms_ipf_Handler}
-	 * @param array $columns array representing the columns to display in the table
-	 * @param object $criteria
-	 * @param array $actions array representing the actions to offer
-	 *
-	 * @return array
+	 * @param \icms_ipf_Handler $objectHandler Handler
+	 * @param bool|\icms_db_criteria_Element $criteria Criteria
+	 * @param string[] $actions array representing the actions to offer
+	 * @param bool $userSide For user side?
 	 */
 	public function __construct(&$objectHandler, $criteria = false, $actions = array('edit', 'delete'), $userSide = false) {
 		$this->_id = $objectHandler->className;

--- a/libraries/icms/ipf/view/Tree.php
+++ b/libraries/icms/ipf/view/Tree.php
@@ -24,9 +24,9 @@ class icms_ipf_view_Tree extends icms_ipf_view_Table {
 	/**
 	 * Construct the tree object
 	 *
-	 * @param object $objectHandler (@link icms_ipf_Handler)
-	 * @param object $criteria		(@link icms_db_criteria_Compo)
-	 * @param array $actions		An array of actions for this object
+	 * @param icms_ipf_Handler $objectHandler Handler
+	 * @param icms_db_criteria_Compo|false $criteria		Criteria to filter results
+	 * @param string[] $actions		An array of actions for this object
 	 * @param boolean $userSide		TRUE - display on the user side; FALSE - do not display
 	 */
 	public function __construct(&$objectHandler, $criteria = false, $actions = array('edit', 'delete'), $userSide = false) {
@@ -47,7 +47,7 @@ class icms_ipf_view_Tree extends icms_ipf_view_Table {
 	/**
 	 * Create a row based on the item and children
 	 *
-	 * @param object	$object	@link icms_ipf_Object
+	 * @param icms_ipf_Object	$object	@IPF object to use add to table row
 	 * @param integer	$level	sub-level of the item
 	 */
 	public function createTableRow($object, $level = 0) {

--- a/libraries/icms/member/Handler.php
+++ b/libraries/icms/member/Handler.php
@@ -135,7 +135,7 @@ class icms_member_Handler {
 	/**
 	 * retrieve groups from the database
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element}
+	 * @param \icms_db_criteria_Element $criteria Criteria
 	 * @param bool $id_as_key use the group's ID as key for the array?
 	 * @return array array of {@link icms_member_group_Object} objects
 	 */
@@ -146,7 +146,7 @@ class icms_member_Handler {
 	/**
 	 * retrieve users from the database
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element}
+	 * @param \icms_db_criteria_Element $criteria Criteria
 	 * @param bool $id_as_key use the group's ID as key for the array?
 	 * @return array array of {@link icms_member_user_Object} objects
 	 */
@@ -157,7 +157,7 @@ class icms_member_Handler {
 	/**
 	 * get a list of groupnames and their IDs
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element} object
+	 * @param \icms_db_criteria_Element $criteria Criteria object
 	 * @return array associative array of group-IDs and names
 	 */
 	public function getGroupList($criteria = null) {
@@ -174,7 +174,7 @@ class icms_member_Handler {
 	 *
 	 * @deprecated	This isn't really a membership method, but for the user handler
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element} object
+	 * @param \icms_db_criteria_Element $criteria Criteria object
 	 * @return array associative array of user-IDs and names
 	 */
 	public function getUserList($criteria = null) {
@@ -321,7 +321,7 @@ class icms_member_Handler {
 	/**
 	 * count users matching certain conditions
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element} object
+	 * @param \icms_db_criteria_Element $criteria Criteria object
 	 * @return int
 	 */
 	public function getUserCount($criteria = null) {
@@ -393,7 +393,7 @@ class icms_member_Handler {
 	 *
 	 * @param string $fieldName name of the field to update
 	 * @param string $fieldValue updated value for the field
-	 * @param object $criteria {@link icms_db_criteria_Element} object
+	 * @param \icms_db_criteria_Element $criteria Criteria object
 	 * @return bool TRUE if success or unchanged, FALSE on failure
 	 */
 	public function updateUsersByField($fieldName, $fieldValue, $criteria = null) {
@@ -419,7 +419,7 @@ class icms_member_Handler {
 	 * Temporary solution
 	 *
 	 * @param int $groups IDs of groups
-	 * @param object $criteria {@link icms_db_criteria_Element} object
+	 * @param \icms_db_criteria_Element $criteria Criteria object
 	 * @param bool $asobject return the users as objects?
 	 * @param bool $id_as_key use the UID as key for the array if $asobject is TRUE
 	 * @return array Array of {@link icms_member_user_Object} objects (if $asobject is TRUE)

--- a/libraries/icms/member/Handler.php
+++ b/libraries/icms/member/Handler.php
@@ -80,7 +80,7 @@ class icms_member_Handler {
 	/**
 	 * create a new group
 	 *
-	 * @return object icms_member_group_Object {@link icms_member_group_Object} reference to the new group
+	 * @return icms_member_group_Object
 	 */
 	public function &createGroup(&$isNew = true) {
 		$inst = & $this->_gHandler->create();
@@ -90,7 +90,7 @@ class icms_member_Handler {
 	/**
 	 * create a new user
 	 *
-	 * @return object icms_member_user_Object {@link icms_member_user_Object} reference to the new user
+	 * @return icms_member_user_Object
 	 */
 	public function &createUser(&$isNew = true) {
 		$inst = & $this->_uHandler->create();
@@ -100,8 +100,8 @@ class icms_member_Handler {
 	/**
 	 * delete a group
 	 *
-	 * @param object $group {@link icms_member_group_Object} reference to the group to delete
-	 * @return bool FALSE if failed
+	 * @param icms_member_group_Object $group reference to the group to delete
+	 * @return bool
 	 */
 	public function deleteGroup(&$group) {
 		$this->_gHandler->delete($group);
@@ -112,8 +112,9 @@ class icms_member_Handler {
 	/**
 	 * delete a user
 	 *
-	 * @param object $user {@link icms_member_user_Object} reference to the user to delete
-	 * @return bool FALSE if failed
+	 * @param icms_member_user_Object $user reference to the user to delete
+	 *
+	 * @return bool
 	 */
 	public function deleteUser(&$user) {
 		$this->_uHandler->delete($user);
@@ -124,9 +125,8 @@ class icms_member_Handler {
 	/**
 	 * insert a group into the database
 	 *
-	 * @param object $group {@link icms_member_group_Object} reference to the group to insert
-	 * @return bool TRUE if already in database and unchanged
-	 * FALSE on failure
+	 * @param icms_member_group_Object $group reference to the group to insert
+	 * @return bool
 	 */
 	public function insertGroup(&$group) {
 		return $this->_gHandler->insert($group);
@@ -137,7 +137,8 @@ class icms_member_Handler {
 	 *
 	 * @param \icms_db_criteria_Element $criteria Criteria
 	 * @param bool $id_as_key use the group's ID as key for the array?
-	 * @return array array of {@link icms_member_group_Object} objects
+	 *
+	 * @return icms_member_group_Object[]
 	 */
 	public function &getGroups($criteria = null, $id_as_key = false) {
 		return $this->_gHandler->getObjects($criteria, $id_as_key);
@@ -148,7 +149,8 @@ class icms_member_Handler {
 	 *
 	 * @param \icms_db_criteria_Element $criteria Criteria
 	 * @param bool $id_as_key use the group's ID as key for the array?
-	 * @return array array of {@link icms_member_user_Object} objects
+	 *
+	 * @return icms_member_user_Object[]
 	 */
 	public function getUsers($criteria = null, $id_as_key = false) {
 		return $this->_uHandler->getObjects($criteria, $id_as_key);
@@ -158,6 +160,7 @@ class icms_member_Handler {
 	 * get a list of groupnames and their IDs
 	 *
 	 * @param \icms_db_criteria_Element $criteria Criteria object
+	 *
 	 * @return array associative array of group-IDs and names
 	 */
 	public function getGroupList($criteria = null) {
@@ -193,7 +196,8 @@ class icms_member_Handler {
 	 *
 	 * @param int $group_id ID of the group
 	 * @param int $user_id ID of the user
-	 * @return object icms_member_group_membership_Object {@link icms_member_group_membership_Object}
+	 *
+	 * @return bool
 	 */
 	public function addUserToGroup($group_id, $user_id) {
 		$mship = & $this->_mHandler->create();
@@ -227,7 +231,7 @@ class icms_member_Handler {
 	 * @param bool $asobject return the users as objects?
 	 * @param int $limit number of users to return
 	 * @param int $start index of the first user to return
-	 * @return array Array of {@link icms_member_user_Object} objects (if $asobject is TRUE)
+	 * @return array|icms_member_user_Object[]
 	 * or of associative arrays matching the record structure in the database.
 	 */
 	public function &getUsersByGroup($group_id, $asobject = false, $limit = 0, $start = 0) {
@@ -265,7 +269,7 @@ class icms_member_Handler {
 	 * log in a user
 	 * @param string $uname username as entered in the login form
 	 * @param string $pwd password entered in the login form
-	 * @return object icms_member_user_Object {@link icms_member_user_Object} reference to the logged in user. FALSE if failed to log in
+	 * @return icms_member_user_Object|false
 	 */
 	public function loginUser($uname, $pwd) {
 
@@ -341,7 +345,7 @@ class icms_member_Handler {
 	/**
 	 * updates a single field in a users record
 	 *
-	 * @param object $user {@link icms_member_user_Object} reference to the {@link icms_member_user_Object} object
+	 * @param icms_member_user_Object $user reference
 	 * @param string $fieldName name of the field to update
 	 * @param string $fieldValue updated value for the field
 	 * @return bool TRUE if success or unchanged, FALSE on failure
@@ -352,34 +356,9 @@ class icms_member_Handler {
 	}
 
 	/**
-	 * logs in a user with an md5 encrypted password
-	 *
-	 * @param string $uname username
-	 * @param string $md5pwd password encrypted with md5
-	 * @return object icms_member_user_Object {@link icms_member_user_Object} reference to the logged in user. FALSE if failed to log in
-	 */
-	/*	function &loginUserMd5($uname, $md5pwd) {
-	 $table = new icms_db_legacy_updater_Table('users');
-	 if ($table->fieldExists('loginname')) {
-	 $criteria = new icms_db_criteria_Compo(new icms_db_criteria_Item('loginname', $uname));
-	 } elseif ($table->fieldExists('login_name')) {
-	 $criteria = new icms_db_criteria_Compo(new icms_db_criteria_Item('login_name', $uname));
-	 } else {
-	 $criteria = new icms_db_criteria_Compo(new icms_db_criteria_Item('uname', $uname));
-	 }
-	 $criteria->add(new icms_db_criteria_Item('pass', $md5pwd));
-	 $user = $this->_uHandler->getObjects($criteria, false);
-	 if (! $user || count($user) != 1) {
-	 $user = false;
-	 return $user;
-	 }
-	 return $user [0];
-	 } */
-
-	/**
 	 * insert a user into the database
 	 *
-	 * @param object $user {@link icms_member_user_Object} reference to the user to insert
+	 * @param \icms_member_user_Object $user User
 	 * @return bool TRUE if already in database and unchanged
 	 * FALSE on failure
 	 */
@@ -403,7 +382,7 @@ class icms_member_Handler {
 	/**
 	 * activate a user
 	 *
-	 * @param object $user {@link icms_member_user_Object} reference to the object
+	 * @param icms_member_user_Object $user User
 	 * @return bool successful?
 	 */
 	public function activateUser(&$user) {
@@ -422,8 +401,8 @@ class icms_member_Handler {
 	 * @param \icms_db_criteria_Element $criteria Criteria object
 	 * @param bool $asobject return the users as objects?
 	 * @param bool $id_as_key use the UID as key for the array if $asobject is TRUE
-	 * @return array Array of {@link icms_member_user_Object} objects (if $asobject is TRUE)
-	 * or of associative arrays matching the record structure in the database.
+	 *
+	 * @return array|icms_member_user_Object[]
 	 */
 	public function getUsersByGroupLink($groups, $criteria = null, $asobject = false, $id_as_key = false) {
 		$ret = array();
@@ -540,8 +519,9 @@ class icms_member_Handler {
 	 * get a list of groups that a user is member of
 	 *
 	 * @param int $user_id ID of the user
-	 * @param bool $asobject return groups as {@link icms_member_group_Object} objects or arrays?
-	 * @return array array of objects or arrays
+	 * @param bool $asobject return groups as icms_member_group_Object objects or arrays?
+	 *
+	 * @return array|icms_member_group_Object[]
 	 */
 	public function &getGroupsByUser($user_id, $asobject = false)
 	{
@@ -560,7 +540,8 @@ class icms_member_Handler {
 	 * retrieve a group
 	 *
 	 * @param int $id ID for the group
-	 * @return object icms_member_group_Object {@link icms_member_group_Object} reference to the group
+	 *
+	 * @return icms_member_group_Object|null
 	 */
 	public function &getGroup($id)
 	{

--- a/libraries/icms/member/group/membership/Handler.php
+++ b/libraries/icms/member/group/membership/Handler.php
@@ -54,8 +54,6 @@ class icms_member_group_membership_Handler extends icms_ipf_Handler {
 	 * retrieve groups for a user
 	 *
 	 * @param int $uid ID of the user
-	 * @param bool $asobject should the groups be returned as {@link icms_member_group_Object}
-	 * objects? FALSE returns associative array.
 	 * @return array array of groups the user belongs to
 	 */
 	public function getGroupsByUser($uid) {
@@ -76,8 +74,6 @@ class icms_member_group_membership_Handler extends icms_ipf_Handler {
 	 * retrieve users belonging to a group
 	 *
 	 * @param int $groupid ID of the group
-	 * @param bool $asobject return users as {@link icms_user_Object} objects?
-	 * FALSE will return arrays
 	 * @param int $limit number of entries to return
 	 * @param int $start offset of first entry to return
 	 * @return array array of users belonging to the group

--- a/libraries/icms/member/groupperm/Object.php
+++ b/libraries/icms/member/groupperm/Object.php
@@ -38,7 +38,7 @@
 /**
  * A group permission
  *
- * These permissions are managed through a {@link icms_member_groupperm_Handler} object
+ * These permissions are managed through a icms_member_groupperm_Handler object
  *
  * @author	Kazumi Ono	<onokazu@xoops.org>
  * @copyright	Copyright (c) 2000 XOOPS.org

--- a/libraries/icms/member/user/Handler.php
+++ b/libraries/icms/member/user/Handler.php
@@ -98,7 +98,7 @@ class icms_member_user_Handler
 	/**
 	 * delete users matching a set of conditions
 	 *
-	 * @param object $criteria {@link icms_db_criteria_Element}
+	 * @param \icms_db_criteria_Element $criteria Criteria
 	 * @return bool FALSE if deletion failed
 	 * @TODO we need to also delete the private messages of the user when we delete them! how do we determine which users were deleted from the criteria????
 	 */

--- a/libraries/icms/messaging/EmailHandler.php
+++ b/libraries/icms/messaging/EmailHandler.php
@@ -66,10 +66,10 @@ class icms_messaging_EmailHandler extends PHPMailer {
 	 * This can be:
 	 * <li>mail (standard PHP function "mail()") (default)
 	 * <li>smtp	(send through any SMTP server, SMTPAuth is supported.
-	 * You must set {@link $Host}, for SMTPAuth also {@link $SMTPAuth},
-	 * {@link $Username}, and {@link $Password}.)
+	 * You must set $Host, for SMTPAuth also $SMTPAuth,
+	 * $Username, and $Password.)
 	 * <li>sendmail (manually set the path to your sendmail program
-	 * to something different than "mail()" uses in {@link $Sendmail})
+	 * to something different than "mail()" uses in $Sendmail)
 	 *
 	 * @var 	string
 	 * @access	private
@@ -79,7 +79,7 @@ class icms_messaging_EmailHandler extends PHPMailer {
 	/**
 	 * set if $Mailer is "sendmail"
 	 *
-	 * Only used if {@link $Mailer} is set to "sendmail".
+	 * Only used if $Mailer is set to "sendmail".
 	 * Contains the full path to your sendmail program or replacement.
 	 * @var 	string
 	 * @access	private
@@ -89,7 +89,7 @@ class icms_messaging_EmailHandler extends PHPMailer {
 	/**
 	 * SMTP Host.
 	 *
-	 * Only used if {@link $Mailer} is set to "smtp"
+	 * Only used if $Mailer is set to "smtp"
 	 * @var 	string
 	 * @access	private
 	 */
@@ -112,7 +112,7 @@ class icms_messaging_EmailHandler extends PHPMailer {
 	/**
 	 * Username for authentication with your SMTP host.
 	 *
-	 * Only used if {@link $Mailer} is "smtp" and {@link $SMTPAuth} is TRUE
+	 * Only used if $Mailer is "smtp" and $SMTPAuth is TRUE
 	 * @var 	string
 	 * @access	private
 	 */
@@ -121,7 +121,7 @@ class icms_messaging_EmailHandler extends PHPMailer {
 	/**
 	 * Password for SMTPAuth.
 	 *
-	 * Only used if {@link $Mailer} is "smtp" and {@link $SMTPAuth} is TRUE
+	 * Only used if $Mailer is "smtp" and $SMTPAuth is TRUE
 	 * @var 	string
 	 * @access	private
 	 */

--- a/libraries/icms/messaging/Handler.php
+++ b/libraries/icms/messaging/Handler.php
@@ -59,7 +59,8 @@ class icms_messaging_Handler {
 	protected $encoding = '8bit';
 
 	/**
-	 * reference to a {@link icms_messaging_EmailHandler}
+	 * reference
+	 *
 	 * @var		icms_messaging_EmailHandler
 	 */
 	private $multimailer;

--- a/libraries/icms/module/Handler.php
+++ b/libraries/icms/module/Handler.php
@@ -130,7 +130,7 @@ class icms_module_Handler
 	 * @param    bool $debug Debug enabled for object?
 	 * @param   bool|object $criteria Criteria for getting object if needed
 	 *
-	 * @return    object  {@link icms_module_Object} FALSE on fail
+	 * @return    \icms_module_Object|false
 	 */
 	public function &get($id, $loadConfig = false, $debug = false, $criteria = false)
 	{
@@ -168,7 +168,7 @@ class icms_module_Handler
 	 *
 	 * @param    string $dirname
 	 * @param    bool $loadConfig set to TRUE in case you want to load the module config in addition
-	 * @return    object  {@link icms_module_Object} FALSE on fail
+	 * @return    \icms_module_Object|false
 	 */
 	public function getByDirname($dirname, $loadConfig = false) {
 		//if (!($module = $this->getFromCache('dirname', $dirname))) {

--- a/libraries/icms/module/Object.php
+++ b/libraries/icms/module/Object.php
@@ -188,8 +188,7 @@ class icms_module_Object
 	 * Get module info
 	 *
 	 * @param   string  	$name
-	 * @return  array|string	Array of module information.
-	 * If {@link $name} is set, returns a single module information item as string.
+	 * @return  array|string|false	Array of module information.
 	 */
 	public function &getInfo($name = null) {
 		if (!isset($this->modinfo)) {$this->loadInfo($this->getVar('dirname')); }

--- a/libraries/icms/view/template/file/Handler.php
+++ b/libraries/icms/view/template/file/Handler.php
@@ -54,7 +54,7 @@ class icms_view_template_file_Handler extends icms_ipf_Handler {
 	 * Loads Template source from DataBase
 	 *
 	 * @see icms_view_template_file_Object
-	 * @param object $tplfile {@link icms_view_template_file_Object} object of the template file to load
+	 * @param \icms_view_template_file_Object $tplfile object of the template file to load
 	 * @return bool TRUE on success, FALSE if fail
 	 */
 	public function loadSource(icms_view_template_file_Object &$tplfile) {
@@ -72,7 +72,7 @@ class icms_view_template_file_Handler extends icms_ipf_Handler {
 
 	/**
 	 * forces Template source into the DataBase
-	 * @param object $tplfile {@link icms_view_template_file_Object} object of the template file to load
+	 * @param icms_view_template_file_Object $tplfile object of the template file to load
 	 * @return bool TRUE on success, FALSE if fail
 	 */
 	public function forceUpdate(&$tplfile) {

--- a/libraries/icms/view/template/set/Handler.php
+++ b/libraries/icms/view/template/set/Handler.php
@@ -54,7 +54,7 @@ class icms_view_template_set_Handler extends icms_ipf_Handler {
 	 *
 	 * @see icms_view_template_set_Object
 	 * @param string $tplset_name of the tempateset to get
-	 * @return object icms_view_template_set_Object {@link icms_view_template_set_Object} reference to the new template
+	 * @return \icms_view_template_set_Object reference to the new template
 	 */
 	public function &getByName($tplset_name) {
 				$criteria = new icms_db_criteria_Item('tplset_name', trim($tplset_name));
@@ -68,10 +68,10 @@ class icms_view_template_set_Handler extends icms_ipf_Handler {
 	 *
 	 * @see icms_view_template_set_Object
 	 *
-	 * @param object $tplset {@link icms_view_template_set_Object} reference to the object of the tempateset to delete
+	 * @param \icms_view_template_set_Object $tplset reference to the object of the tempateset to delete
 	 * @param bool $force Force delete?
 	 *
-	 * @return object icms_view_template_set_Object {@link icms_view_template_set_Object} reference to the new template
+	 * @return bool
 	 */
 	public function delete(&$tplset, $force = false) {
 		if (!parent::delete($tplset, $force)) {

--- a/libraries/icms/view/theme/Object.php
+++ b/libraries/icms/view/theme/Object.php
@@ -128,7 +128,7 @@ class icms_view_theme_Object {
 	 * Initializes this theme
 	 *
 	 * Upon initialization, the theme creates its template engine and instanciates the
-	 * plug-ins from the specified {@link $plugins} list. If the theme is a 2.0 theme, that does not
+	 * plug-ins from the specified $plugins list. If the theme is a 2.0 theme, that does not
 	 * display redirection messages, the HTTP redirections system is disabled to ensure users will
 	 * see the redirection screen.
 	 *

--- a/libraries/smarty/icms_plugins/compiler.foreachq.php
+++ b/libraries/smarty/icms_plugins/compiler.foreachq.php
@@ -16,8 +16,7 @@
 /**
  * Quick foreach template plug-in
  *
- * This plug-in works as a direct replacement for the original Smarty
- * {@link http://smarty.php.net/manual/en/language.function.foreach.php foreach} function.
+ * This plug-in works as a direct replacement for the original Smarty foreach function.
  *
  * The difference with <var>foreach</var> is minimal in terms of functionality, but can boost your templates
  * a lot: foreach duplicates the content of the variable that is iterated, to ensure non-array

--- a/libraries/smarty/icms_plugins/compiler.includeq.php
+++ b/libraries/smarty/icms_plugins/compiler.includeq.php
@@ -18,8 +18,7 @@
  *
  * Like smarty_compiler_foreachq, this plug-in has been written to provide
  * a faster version of an already existing Smarty function. <var>includeq</var> can be used
- * as a replacement for the Smarty
- * {@link http://smarty.php.net/manual/en/language.function.include.php include} function as long
+ * as a replacement for the Smarty include function as long
  * as you are aware of the differences between them.
  *
  * Normally, when you include a template, Smarty does the following:

--- a/libraries/smarty/icms_plugins/compiler.includeq.php
+++ b/libraries/smarty/icms_plugins/compiler.includeq.php
@@ -16,7 +16,7 @@
 /**
  * Quick include template plug-in
  *
- * Like {@link smarty_compiler_foreachq() foreachq}, this plug-in has been written to provide
+ * Like smarty_compiler_foreachq, this plug-in has been written to provide
  * a faster version of an already existing Smarty function. <var>includeq</var> can be used
  * as a replacement for the Smarty
  * {@link http://smarty.php.net/manual/en/language.function.include.php include} function as long

--- a/libraries/smarty/icms_plugins/compiler.xoAppUrl.php
+++ b/libraries/smarty/icms_plugins/compiler.xoAppUrl.php
@@ -37,8 +37,7 @@
  * The is the slowest mode, and its use should be prevented unless necessary. Here,
  * the URL is generated dynamically each time the template is displayed, thus allowing
  * you to use the value of a template variable in the location string. To use it, you
- * must surround your location with double-quotes ("), and use the
- * {@link http://smarty.php.net/manual/en/language.syntax.quotes.php Smarty quoted strings}
+ * must surround your location with double-quotes ("), and use the Smarty quoted strings
  * syntax to insert variables values.
  *
  * <code>

--- a/libraries/smarty/icms_plugins/compiler.xoImgUrl.php
+++ b/libraries/smarty/icms_plugins/compiler.xoImgUrl.php
@@ -16,7 +16,7 @@
 /**
  * Inserts the URL of a file resource customizable by themes
  *
- * This plug-in works like the {@link smarty_compiler_xoAppUrl() xoAppUrl} plug-in,
+ * This plug-in works like the smarty_compiler_xoAppUrl plug-in,
  * except that it is intended to generate the URL of resource files customizable by
  * themes.
  *

--- a/modules/system/class/Blocks.php
+++ b/modules/system/class/Blocks.php
@@ -210,7 +210,14 @@ class mod_system_Blocks extends icms_view_block_Object {
 	/**
 	 * Create the form for this object
 	 *
-	 * @return a {@link SmartobjectForm} object for this object
+	 * @param string $form_caption Form caption
+	 * @param string $form_name Form name
+	 * @param bool|string $form_action Form action
+	 * @param string $submit_button_caption Submit button caption
+	 * @param bool $cancel_js_action Cancel JS action?
+	 * @param bool $captcha Use captcha?
+	 *
+	 * @return icms_form_Base
 	 *
 	 * @see icms_ipf_ObjectForm::icms_ipf_ObjectForm()
 	 */
@@ -220,8 +227,7 @@ class mod_system_Blocks extends icms_view_block_Object {
 			$this->hideFieldFromForm('c_type');
 		}
 
-		$form = new icms_ipf_form_Base($this, $form_name, $form_caption, $form_action, null, $submit_button_caption, $cancel_js_action, $captcha);
-		return $form;
+		return new icms_ipf_form_Base($this, $form_name, $form_caption, $form_action, null, $submit_button_caption, $cancel_js_action, $captcha);
 	}
 
 	/**


### PR DESCRIPTION
As previously we have noticed, we have many comments with `@link` tag that is used not everytime correctly. I thought that was related to IDE but later I found out that such lines comes at least from somewhere 2012.  I think probably older phpdocs tools needed them. But right now these comments doesn't makes much sense so I have removed or replaced to something that is more useful.