### PR TITLE
Fixes 'Notice: Only variables should be passed by reference in file /libraries/icms.php line 195'

### DIFF
--- a/libraries/icms.php
+++ b/libraries/icms.php
@@ -191,7 +191,8 @@ final class icms extends Container {
 					}
 				}
 			}
-			$instance->add($real_name, $class ? (new $class($instance->get('xoopsDB'))) : false);
+			$db = $instance->get('xoopsDB');
+			$instance->add($real_name, $class ? (new $class($db)) : false);
 		}
 		$handler = $instance->get($real_name);
 		if (!$handler && !$optional) {


### PR DESCRIPTION
Simple fix for removing one of notices messages.