### PR TITLE
Fixes 'Warning: Declaration of icms_data_comment_Handler::getList($criteria, $limit, $start, $debug) should be compatible with icms_ipf_Handler::getList($criteria = NULL, $limit = 0, $start = 0, $debug = false) in file /libraries/icms/data/comment/Handler.php line 0'

### DIFF
--- a/libraries/icms/data/comment/Handler.php
+++ b/libraries/icms/data/comment/Handler.php
@@ -54,6 +54,8 @@ class icms_data_comment_Handler extends icms_ipf_Handler {
 			parent::__construct($db, 'data_comment', 'com_id', 'com_title', 'com_text', 'icms', 'xoopscomments', 'com_id');
 		}
 
+
+
 	/**
 	 * Get a list of comments
 	 *
@@ -61,7 +63,7 @@ class icms_data_comment_Handler extends icms_ipf_Handler {
 	 *
 	 * @return  array   Array of raw database records
 	 */
-	public function getList($criteria = null, $limit, $start, $debug) {
+	public function getList($criteria = null, $limit = 0, $start = 0, $debug = false) {
 			$comments = parent::getList($criteria, $limit, $start, $debug);
 			return array_keys($comments);
 	}

--- a/libraries/icms/data/comment/Handler.php
+++ b/libraries/icms/data/comment/Handler.php
@@ -54,8 +54,6 @@ class icms_data_comment_Handler extends icms_ipf_Handler {
 			parent::__construct($db, 'data_comment', 'com_id', 'com_title', 'com_text', 'icms', 'xoopscomments', 'com_id');
 		}
 
-
-
 	/**
 	 * Get a list of comments
 	 *


### PR DESCRIPTION
Simple fix for newer PHP versions