### PR TITLE
Move prototype inclusion so trust_path creation works fixes #569

### DIFF
--- a/htdocs/install/install_tpl.php
+++ b/htdocs/install/install_tpl.php
@@ -48,7 +48,6 @@ if (isset($_COOKIE['xo_install_lang'])) {
 	<script type="text/javascript" src="../libraries/jquery/jquery.js"></script>
 	<script type="text/javascript" src="stylesheetToggle.js"></script>
 	<script type="text/javascript" src="jquery.scrollTo.js"></script>
-	<script type="text/javascript" src="prototype.js"></script>
 	<script type="text/javascript">
 		$(function () {
 			$.stylesheetInit();

--- a/htdocs/install/page_dbsettings.php
+++ b/htdocs/install/page_dbsettings.php
@@ -344,6 +344,7 @@ if (!empty ($error)) {
 	echo '<div class="x2-note error">' . $error . "</div>\n";
 }
 ?>
+	<script type="text/javascript" src="prototype.js"></script>
 	<script type="text/javascript">
 		function setFormFieldCollation(id, val) {
 			if (val == '') {


### PR DESCRIPTION
Prototype was interfering with pathsettings.js. Since prototype is only needed on the dbsettings page, moving there to resolve this and not break #529 