### PR TITLE
Run tests only for master branch and if new commits has correct extensions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,10 @@ on:
   pull_request:
     branches:
       - master
-      - 'branches/**'
+    paths:
+      - .github/workflows/test.yml
+      - '**.js'
+      - '**.php'
 
 jobs:
   run:


### PR DESCRIPTION
Only master branch has tests, so running tests from other release branches removed.

Also, tests will now run only if changes includes *.php or/and *.js or changed test workflow file.