### PR TITLE
Fix empty login on Chrome-based browsers

### DIFF
--- a/htdocs/user.php
+++ b/htdocs/user.php
@@ -50,7 +50,7 @@ $redirect = isset($_GET['xoops_redirect'])
 		? $_GET['xoops_redirect']
 		: isset($_POST['xoops_redirect'])
 			? $_POST['xoops_redirect']
-			: FALSE;
+			: ICMS_URL;
 if ($redirect) {
 	$redirect = htmlspecialchars(trim($redirect), ENT_QUOTES);
 	$isExternal = FALSE;


### PR DESCRIPTION
Fix #100
This will fix the long-standing bug that happens when you login from the user.php page (and not using the block on the homepage or somewhere else).