### PR TITLE
Fix blank page after login

### DIFF
--- a/htdocs/modules/system/templates/system_userform.html
+++ b/htdocs/modules/system/templates/system_userform.html
@@ -13,7 +13,7 @@
 			    	<div><input type="checkbox" name="rememberme" value="On" /><{$lang_rememberme}><br /></div>
 			    <{/if}>
 			    <div><input type="hidden" name="op" value="login" /></div>
-		    	<div><input type="hidden" name="xoops_redirect" value="<{$redirect_page}>"/>
+		    	<div><input type="hidden" name="xoops_redirect" value="<{$icms_requesturi}>"/>
 			    <br />
 		    	<input type="submit" value="<{$lang_login}>" /></div>
 			</form>


### PR DESCRIPTION
no longer using the xoops_redirect, but the icms_requesturi variable fixes the issue with the blank redirect.

Fixes the issue, instead of my previous PR.