### PR TITLE
Clears cache when installing, uninstalling or updating module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,7 @@ jobs:
         run: php -v
       - name: Verify MySQL connection
         run: |
+          sudo apt-get update -q -y
           sudo apt-get install -y mysql-client
           mysql --host 127.0.0.1 --port ${{ job.services.mysql.ports['3306'] }} -uroot -picms -e "SHOW DATABASES"
       - name: Get composer cache directory

--- a/composer.json
+++ b/composer.json
@@ -324,6 +324,30 @@
           "setup_step.module.uninstall"
         ]
       },
+      "\\ImpressCMS\\Core\\SetupSteps\\Module\\Install\\CacheClearSetupStep": {
+        "tags": [
+          "setup_step.module.install"
+        ],
+        "arguments": [
+          "cache"
+        ]
+      },
+      "\\ImpressCMS\\Core\\SetupSteps\\Module\\Uninstall\\CacheClearSetupStep": {
+        "tags": [
+          "setup_step.module.uninstall"
+        ],
+        "arguments": [
+          "cache"
+        ]
+      },
+      "\\ImpressCMS\\Core\\SetupSteps\\Module\\Update\\CacheClearSetupStep": {
+        "tags": [
+          "setup_step.module.update"
+        ],
+        "arguments": [
+          "cache"
+        ]
+      },
       "CKeditor": {
         "class": "\\ImpressCMS\\Editors\\CKeditor\\Editor",
         "tags": [

--- a/core/SetupSteps/Module/Install/CacheClearSetupStep.php
+++ b/core/SetupSteps/Module/Install/CacheClearSetupStep.php
@@ -1,0 +1,48 @@
+<?php
+
+
+namespace ImpressCMS\Core\SetupSteps\Module\Install;
+
+use Apix\Cache\PsrCache\Pool;
+use icms_module_Object;
+use ImpressCMS\Core\SetupSteps\OutputDecorator;
+use ImpressCMS\Core\SetupSteps\SetupStepInterface;
+
+/**
+ * Clears cache
+ *
+ * @package ImpressCMS\Core\SetupSteps\Module\Install
+ */
+class CacheClearSetupStep implements SetupStepInterface
+{
+	/**
+	 * CacheClearSetupStep constructor.
+	 *
+	 * @param Pool $cachePool
+	 */
+	public function __construct(Pool $cachePool)
+	{
+		$this->cache = $cachePool;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function execute(icms_module_Object $module, OutputDecorator $output, ...$params): bool
+	{
+		$output->info(_MD_AM_CLEARING_CACHE);
+
+		$this->cache->clear();
+		\icms::getInstance()->boot(false);
+
+		return true;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getPriority(): int
+	{
+		return PHP_INT_MAX;
+	}
+}

--- a/core/SetupSteps/Module/Uninstall/CacheClearSetupStep.php
+++ b/core/SetupSteps/Module/Uninstall/CacheClearSetupStep.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace ImpressCMS\Core\SetupSteps\Module\Uninstall;
+
+use ImpressCMS\Core\SetupSteps\Module\Install\CacheClearSetupStep as OriginalCacheClearSetupStep;
+use ImpressCMS\Core\SetupSteps\SetupStepInterface;
+
+/**
+ * Clears cache
+ *
+ * @package ImpressCMS\Core\SetupSteps\Module\Uninstall
+ */
+class CacheClearSetupStep extends OriginalCacheClearSetupStep implements SetupStepInterface
+{
+
+}

--- a/core/SetupSteps/Module/Update/CacheClearSetupStep.php
+++ b/core/SetupSteps/Module/Update/CacheClearSetupStep.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace ImpressCMS\Core\SetupSteps\Module\Update;
+
+use ImpressCMS\Core\SetupSteps\Module\Install\CacheClearSetupStep as OriginalCacheClearSetupStep;
+use ImpressCMS\Core\SetupSteps\SetupStepInterface;
+
+/**
+ * Clears cache
+ *
+ * @package ImpressCMS\Core\SetupSteps\Module\Update
+ */
+class CacheClearSetupStep extends OriginalCacheClearSetupStep implements SetupStepInterface
+{
+
+}

--- a/libraries/icms.php
+++ b/libraries/icms.php
@@ -317,7 +317,7 @@ final class icms extends Container {
 			$this->registerCommonServiceVariables();
 		}
 
-		if (!(defined('ICMS_MIGRATION_MODE') && ICMS_MIGRATION_MODE)) {
+		if (!(defined('ICMS_MIGRATION_MODE') && ICMS_MIGRATION_MODE) && $registerCommonServices) {
 			$this->loadComposerDefinition(
 				new \ImpressCMS\Core\ComposerDefinitions\RoutesComposerDefinition()
 			);

--- a/modules/system/language/english/admin/modules.php
+++ b/modules/system/language/english/admin/modules.php
@@ -166,3 +166,5 @@ define('_MD_AM_COPY_ASSETS_INFO', 'Updating assets...');
 define('_MD_AM_COPY_ASSETS_DELETE_OLD', 'Deleting old public assets content...');
 define('_MD_AM_COPY_ASSETS_COPYING', 'Copying \'%s\'...');
 define('_MD_AM_COPY_ASSETS_DELETING', 'Deleting assets...');
+
+define('_MD_AM_CLEARING_CACHE', 'Clearing cache...');


### PR DESCRIPTION
Adds a step that clears cache when installing, uninstalling or updating module, so when routes, services, providers will be rebuild also depending module actions (previously user needed to delete cache to see differences manually).