### PR TITLE
Fixes license in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description": "ImpressCMS is an open source content management system with a focus on security and speed",
   "minimum-stability": "dev",
   "prefer-stable": true,
-  "license": "GPL-2.0-only",
+  "license": "GPL-2.0-or-later",
   "homepage": "https://impresscms.org",
   "authors": [
     {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "345381a686e01eca473e817f76162d87",
+    "content-hash": "69cc09fb6b3d1014a4ff127a148fff62",
     "packages": [
         {
             "name": "0.0.0/composer-include-files",


### PR DESCRIPTION
It seems we incorrectly said in our composer.json that we use GPLv2.0 only license but in reality our code is based on GPLv2.0 or later license (I have checked differences in our code base + all Xoops inherited file headers). 