### PR TITLE
Changed way how paths in subfolder would be handled

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
     "league/flysystem": "^1.0.51",
     "league/route": "^4.3",
     "lulco/phoenix": "^1.1",
+    "middlewares/base-path": "^2.0",
     "middlewares/encoder": "^2.1",
     "monolog/monolog": "^2.0",
     "narrowspark/http-emitter": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "69cc09fb6b3d1014a4ff127a148fff62",
+    "content-hash": "ec161fc944214fc428341af81021faee",
     "packages": [
         {
             "name": "0.0.0/composer-include-files",
@@ -1613,6 +1613,57 @@
                 "status"
             ],
             "time": "2020-04-16T13:19:50+00:00"
+        },
+        {
+            "name": "middlewares/base-path",
+            "version": "v2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/middlewares/base-path.git",
+                "reference": "1427d8a4976eed887626a6b99b1758e4b7b8e8fc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/middlewares/base-path/zipball/1427d8a4976eed887626a6b99b1758e4b7b8e8fc",
+                "reference": "1427d8a4976eed887626a6b99b1758e4b7b8e8fc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2",
+                "psr/http-server-middleware": "^1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.0",
+                "middlewares/utils": "^3.0",
+                "oscarotero/php-cs-fixer-config": "^1.0",
+                "phpunit/phpunit": "^8.1",
+                "squizlabs/php_codesniffer": "^3.0",
+                "zendframework/zend-diactoros": "^2.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Middlewares\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Middleware to remove the prefix from the uri path of the request.",
+            "homepage": "https://github.com/middlewares/base-path",
+            "keywords": [
+                "http",
+                "middleware",
+                "psr-15",
+                "psr-7",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/middlewares/base-path/issues",
+                "source": "https://github.com/middlewares/base-path/tree/v2.0.0"
+            },
+            "time": "2019-11-30T01:50:59+00:00"
         },
         {
             "name": "middlewares/encoder",
@@ -5349,76 +5400,6 @@
             "time": "2016-10-03T07:35:21+00:00"
         },
         {
-            "name": "symfony/debug",
-            "version": "v4.4.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/debug.git",
-                "reference": "346636d2cae417992ecfd761979b2ab98b339a45"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/346636d2cae417992ecfd761979b2ab98b339a45",
-                "reference": "346636d2cae417992ecfd761979b2ab98b339a45",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1.3",
-                "psr/log": "~1.0"
-            },
-            "conflict": {
-                "symfony/http-kernel": "<3.4"
-            },
-            "require-dev": {
-                "symfony/http-kernel": "^3.4|^4.0|^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "4.4-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Debug\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Debug Component",
-            "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-03-27T16:54:36+00:00"
-        },
-        {
             "name": "symfony/yaml",
             "version": "v4.4.2",
             "source": {
@@ -5544,5 +5525,5 @@
         "ext-session": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/core/Controllers/LegacyController.php
+++ b/core/Controllers/LegacyController.php
@@ -29,12 +29,7 @@ class LegacyController
 	 */
 	public function proxy(ServerRequestInterface $request): ResponseInterface
 	{
-		$prefixOfRoute = rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
-		$filePath = $prefixOfRoute ? mb_substr($request->getUri()->getPath(), mb_strlen($prefixOfRoute)) : $request->getUri()->getPath();
-		if (substr($filePath, -1) === '/') {
-			$filePath = substr($prefixOfRoute, 0, -1);
-		}
-		$path = ICMS_ROOT_PATH . DIRECTORY_SEPARATOR . $filePath;
+		$path = ICMS_ROOT_PATH . DIRECTORY_SEPARATOR . $request->getUri()->getPath();
 		if (pathinfo($path, PATHINFO_EXTENSION) === 'php') {
 			$inAdmin = (defined('ICMS_IN_ADMIN') && (int)ICMS_IN_ADMIN);
 			$module = $request->getAttribute('module');

--- a/core/Extensions/ComposerDefinitions/RoutesComposerDefinition.php
+++ b/core/Extensions/ComposerDefinitions/RoutesComposerDefinition.php
@@ -103,7 +103,6 @@ class RoutesComposerDefinition implements ComposerDefinitionInterface
 			' */',
 			'$strategy = $router->getStrategy();',
 			'$container = $strategy->getContainer();',
-			'',
 		];
 
 		$this->addMiddlewaresDependingOnConfig($ret);
@@ -120,7 +119,6 @@ class RoutesComposerDefinition implements ComposerDefinitionInterface
 			) .
 			');';
 
-		$prefixOfRoute = $this->getPrefixPathOfRoute();
 		$routes = array_merge(
 			$this->getOldStyleRoutes(),
 			$data['routes'] ?? []
@@ -155,7 +153,7 @@ class RoutesComposerDefinition implements ComposerDefinitionInterface
 				$ret[] = $linePrefix . sprintf(
 					'    ->map(%s, %s, %s)%s',
 					var_export($parsedDefinition['method'], true),
-					var_export(($group === ''? $prefixOfRoute : '') . $parsedDefinition['path'], true),
+					var_export( $parsedDefinition['path'], true),
 					var_export($parsedDefinition['handler'], true),
 					$hasExtraConfig ? '' : ';'
 				);
@@ -216,15 +214,6 @@ class RoutesComposerDefinition implements ComposerDefinitionInterface
 		}
 
 		file_put_contents($this->getCacheFilename(), implode(PHP_EOL, $ret), LOCK_EX);
-	}
-
-	/**
-	 * Gets prefix path of route
-	 *
-	 * @return string
-	 */
-	protected function getPrefixPathOfRoute() {
-		return rtrim(dirname($_SERVER['SCRIPT_NAME']), '/');
 	}
 
 	/**
@@ -292,7 +281,6 @@ class RoutesComposerDefinition implements ComposerDefinitionInterface
 		);
 		$group =  str_replace(ICMS_ROOT_PATH, '', $path);
 		$groupLen = mb_strlen($group);
-		$group = $this->getPrefixPathOfRoute() . $group;
 
 		$handler = LegacyController::class . '::proxy';
 		/**


### PR DESCRIPTION
From now if ImpressCMS is installed in subfolder and moved to other folder, no cache regeneration would be needed.

Also, this probably would fix #785 