### PR TITLE
Prevents using submitted filenames with ../ for controller

### DIFF
--- a/htdocs/libraries/icms/ipf/Controller.php
+++ b/htdocs/libraries/icms/ipf/Controller.php
@@ -51,6 +51,7 @@ class icms_ipf_Controller {
 			switch ($icmsObj->vars[$key]['data_type']) {
 				case XOBJ_DTYPE_IMAGE:
 					if (isset($_POST['url_' . $key]) && $_POST['url_' . $key] !='') {
+						$_POST['url_' . $key] = str_replace('../', '/', $_POST['url_' . $key]);
 						$eventResult = $this->handler->executeEvent('beforeFileUnlink', $icmsObj);
 						if (!$eventResult) {
 							$icmsObj->setErrors("An error occured during the beforeFileUnlink event");
@@ -98,7 +99,7 @@ class icms_ipf_Controller {
 						$fileObj->setVar('mid', $_POST['mid_' . $key]);
 						$fileObj->setVar('caption', $_POST['caption_' . $key]);
 						$fileObj->setVar('description', $_POST['desc_' . $key]);
-						$fileObj->setVar('url', $_POST['url_' . $key]);
+						$fileObj->setVar('url', str_replace('../', '/', $_POST['url_' . $key]));
 						if (!($fileObj->getVar('url') == '' && $fileObj->getVar('url') == '' && $fileObj->getVar('url') == '')) {
 							$res = $icmsObj->storeFileObj($fileObj);
 							if ($res) {

--- a/htdocs/libraries/icms/ipf/Controller.php
+++ b/htdocs/libraries/icms/ipf/Controller.php
@@ -51,7 +51,7 @@ class icms_ipf_Controller {
 			switch ($icmsObj->vars[$key]['data_type']) {
 				case XOBJ_DTYPE_IMAGE:
 					if (isset($_POST['url_' . $key]) && $_POST['url_' . $key] !='') {
-						$_POST['url_' . $key] = str_replace('../', '/', $_POST['url_' . $key]);
+						$_POST['url_' . $key] = preg_replace('|[\.]+\/|', './', $_POST['url_' . $key]);
 						$eventResult = $this->handler->executeEvent('beforeFileUnlink', $icmsObj);
 						if (!$eventResult) {
 							$icmsObj->setErrors("An error occured during the beforeFileUnlink event");
@@ -99,7 +99,7 @@ class icms_ipf_Controller {
 						$fileObj->setVar('mid', $_POST['mid_' . $key]);
 						$fileObj->setVar('caption', $_POST['caption_' . $key]);
 						$fileObj->setVar('description', $_POST['desc_' . $key]);
-						$fileObj->setVar('url', str_replace('../', '/', $_POST['url_' . $key]));
+						$fileObj->setVar('url', preg_replace('|[\.]+\/|', './', $_POST['url_' . $key]));
 						if (!($fileObj->getVar('url') == '' && $fileObj->getVar('url') == '' && $fileObj->getVar('url') == '')) {
 							$res = $icmsObj->storeFileObj($fileObj);
 							if ($res) {


### PR DESCRIPTION
Fixes possibility to use relative filenames as POST values for deleting some content via IPFController.

This was found after investingating https://hackerone.com/reports/1035311 by siva teja (siva12)

Idk why all file was marked as changed. Changes were only on lines 54 and 102.