### PR TITLE
Temp fix: use composer v1.0 for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: curl, gd, pdo_mysql, json, mbstring, pcre, session
           ini-values: post_max_size=256M
-          #coverage: xdebug
+          coverage: none
           tools: composer:v${{ matrix.composer }}
       - name: Check PHP Version
         run: php -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,8 +82,8 @@ jobs:
           # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
-      - name: Install Composer dependencies
-        run: composer install --no-progress --no-suggest --no-dev --prefer-dist --optimize-autoloader
+      - name: Install Composer dependencies (with dev)
+        run: composer install --no-progress --no-suggest --prefer-dist --optimize-autoloader
         continue-on-error: ${{ matrix.experimental }}
       - name: Installing ImpressCMS
         env:
@@ -130,6 +130,9 @@ jobs:
           ls tests/ -la
           ./bin/phpunit --testdox
           mv ./storage/log/clover.xml ./clover.xml
+        continue-on-error: ${{ matrix.experimental }}
+      - name: Install Composer dependencies (without dev)
+        run: composer install --no-progress --no-dev --no-suggest --prefer-dist --optimize-autoloader
         continue-on-error: ${{ matrix.experimental }}
       - name: Commiting CodeClimate data
         run: GIT_BRANCH=$GITHUB_REF GIT_COMMIT_SHA=$GITHUB_SHA ./cc-test-reporter after-build --exit-code $? -t clover -r ad1f334232dc545de86fbe07abfd55145ebc0be0530cc25f4ebab9bec35b67e7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,35 +16,33 @@ on:
 
 jobs:
   run:
-    runs-on: ${{ matrix.operating-system }}
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       max-parallel: 3
       matrix:
-        operating-system:
+        os:
           - ubuntu-latest
           #- windows-latest # Todo: make it work also for windows
           #- macOS-latest # Todo: make it work also for macos
-        php-versions:
+        php:
           - 7.3
           - 7.4
-        database-system:
+        database:
           - mysql:5.6
           - mariadb:10.1
+        composer:
+          - 1
         experimental: [false]
         include:
-          - operating-system: ubuntu-latest
-            php-versions: 8.0
-            database-system: mysql:5.6
+          - os: ubuntu-latest
+            php: 8.0
+            database: mysql:5.6
             experimental: true
-          - operating-system: ubuntu-latest
-            php-versions: 8.0
-            database-system: mariadb:10.1
-            experimental: true
-    name: PHP ${{ matrix.php-versions }} with ${{ matrix.database-system }} test on ${{ matrix.operating-system }} [${{ matrix.experimental }}]
+    name: Test - php:${{ matrix.php }}; ${{ matrix.database }}; ${{ matrix.os }}; composer:${{ matrix.os }}
     services:
       mysql:
-        image: ${{ matrix.database-system }}
+        image: ${{ matrix.database }}
         env:
           MYSQL_ROOT_PASSWORD: icms
           MYSQL_DATABASE: icms
@@ -61,11 +59,11 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@master
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php }}
           extensions: curl, gd, pdo_mysql, json, mbstring, pcre, session
           ini-values: post_max_size=256M
           coverage: xdebug
-          tools: phpunit:9.4.3
+          tools: phpunit:9.4.3, composer:v${{ matrix.composer }}
       - name: Check PHP Version
         run: php -v
       - name: Verify MySQL connection

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
             php: 8.0
             database: mysql:5.6
             experimental: true
-    name: Test - php:${{ matrix.php }}; ${{ matrix.database }}; ${{ matrix.os }}; composer:${{ matrix.os }}
+    name: Test - php:${{ matrix.php }}; ${{ matrix.database }}; ${{ matrix.os }}; composer:${{ matrix.composer }}
     services:
       mysql:
         image: ${{ matrix.database }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
           extensions: curl, gd, pdo_mysql, json, mbstring, pcre, session
           ini-values: post_max_size=256M
           coverage: xdebug
-          tools: phpunit:9.4.3, composer:v${{ matrix.composer }}
+          tools: composer:v${{ matrix.composer }}
       - name: Check PHP Version
         run: php -v
       - name: Verify MySQL connection
@@ -128,7 +128,7 @@ jobs:
           DB_PORT: ${{ job.services.mysql.ports['3306'] }}
         run: |
           ls tests/ -la
-          phpunit --testdox
+          ./bin/phpunit --testdox
           mv ./storage/log/clover.xml ./clover.xml
         continue-on-error: ${{ matrix.experimental }}
       - name: Commiting CodeClimate data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: curl, gd, pdo_mysql, json, mbstring, pcre, session
           ini-values: post_max_size=256M
-          coverage: xdebug
+          #coverage: xdebug
           tools: composer:v${{ matrix.composer }}
       - name: Check PHP Version
         run: php -v
@@ -134,7 +134,7 @@ jobs:
       - name: Install Composer dependencies (without dev)
         run: composer install --no-progress --no-dev --no-suggest --prefer-dist --optimize-autoloader
         continue-on-error: ${{ matrix.experimental }}
-      - name: Commiting CodeClimate data
-        run: GIT_BRANCH=$GITHUB_REF GIT_COMMIT_SHA=$GITHUB_SHA ./cc-test-reporter after-build --exit-code $? -t clover -r ad1f334232dc545de86fbe07abfd55145ebc0be0530cc25f4ebab9bec35b67e7
-        if: ${{ success() }}
-        continue-on-error: ${{ matrix.experimental }}
+#      - name: Commiting CodeClimate data
+#        run: GIT_BRANCH=$GITHUB_REF GIT_COMMIT_SHA=$GITHUB_SHA ./cc-test-reporter after-build --exit-code $? -t clover -r ad1f334232dc545de86fbe07abfd55145ebc0be0530cc25f4ebab9bec35b67e7
+#        if: ${{ success() }}
+#        continue-on-error: ${{ matrix.experimental }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           ls tests/ -la
           ./bin/phpunit --testdox
-          mv ./storage/log/clover.xml ./clover.xml
+        #  mv ./storage/log/clover.xml ./clover.xml
         continue-on-error: ${{ matrix.experimental }}
       - name: Install Composer dependencies (without dev)
         run: composer install --no-progress --no-dev --no-suggest --prefer-dist --optimize-autoloader


### PR DESCRIPTION
Because we still can't use composer 2.0 due mindplay-dk/composer-locator#8 issue at least for a while we still require to use composer 1.0 for 2.0 installations.