### PR TITLE
Remove whitesource config

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,8 +1,0 @@
-##########################################################
-####    WhiteSource Integration configuration file    ####
-##########################################################
-
-# Configuration #
-#---------------#
-ws.repo.scan=true
-vulnerable.check.run.conclusion.level=failure


### PR DESCRIPTION
Whitesource tries to scan .js files in composer packages installations and I didn't find any info how to prevent that, so I have decided to remove it.

We use Dependabot and HackerOne. These services I think could replace the need for Whitesource.