### PR TITLE
Fixed null response bug for root path instalations

### DIFF
--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -99,6 +99,8 @@ if ($basePath !== '/' && $basePath !== null) {
 		);
 	}
 	unset($path, $uri);
+} else {
+	$request = ServerRequest::fromGlobals();
 }
 unset($basePath);
 


### PR DESCRIPTION
Accedently I found that such bug exists. For such installations user will get fatal error on any page.