### PR TITLE
Fixed release drafter config to use correct GitHub labels when sorting tickets

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,15 +3,15 @@ tag-template: 'v$NEXT_PATCH_VERSION'
 categories:
   - title: '🚀 Features'
     labels:
-      - 'feature'
       - 'enhancement'
   - title: '🐛 Bug Fixes'
     labels:
-      - 'fix'
-      - 'bugfix'
       - 'bug'
+      - 'security vulnerability'
   - title: '🧰 Maintenance'
-    label: 'chore'
+    labels:
+      - 'dependencies'
+      - 'infrastructure'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## What's Changed


### PR DESCRIPTION
(as title says)