### PR TITLE
Added filter-by-commitish option in release drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -17,3 +17,4 @@ template: |
   ## What's Changed
 
   $CHANGES
+filter-by-commitish: true


### PR DESCRIPTION
I'm not sure 100% but from documentation it seems this could fix issue when 1.4.x and 2.x are losing changes when regenerating new changelog.