### PR TITLE
Added dependabot v2 config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# Documentation about this file can be found here
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "11:00"
+    labels:
+      - "composer"
+      - "dependencies"
+    versioning-strategy: lockfile-only
+    ignore:
+      - dependency-name: composer/composer
+        versions:
+          - "> 1.10.13"
+          - "< 2"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      time: "11:00"
+    labels:
+      - "dependencies"
+      - "infrastructure"
+  - package-ecosystem: gitsubmodule
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      time: "11:00"
+    labels:
+      - "dependencies"
+      - "infrastructure"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,4 +32,4 @@ updates:
       time: "11:00"
     labels:
       - "dependencies"
-      - "infrastructure"
+      - "submodules"


### PR DESCRIPTION
GitHub is integrating dependabot and will remove dependabot website in near future, so to keep using this amazing service and to have some new cool features new configuration file is needed.