### PR TITLE
Added smarty 'trans' block and 'trans' variable modifier for translations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -246,6 +246,22 @@
           "smarty.modifier"
         ]
       },
+      "\\ImpressCMS\\Core\\Extensions\\Smarty\\Modifiers\\TransVarModifier": {
+        "arguments": [
+          "translator"
+        ],
+        "tags": [
+          "smarty.modifier"
+        ]
+      },
+      "\\ImpressCMS\\Core\\Extensions\\Smarty\\Blocks\\TransBlock": {
+        "arguments": [
+          "translator"
+        ],
+        "tags": [
+          "smarty.block"
+        ]
+      },
       "\\ImpressCMS\\Core\\Extensions\\Smarty\\Functions\\ResizeImageFunction": {
         "arguments": [
           "cache"

--- a/core/Extensions/Smarty/Blocks/TransBlock.php
+++ b/core/Extensions/Smarty/Blocks/TransBlock.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace ImpressCMS\Core\Extensions\Smarty\Blocks;
+
+use ImpressCMS\Core\Extensions\Smarty\SmartyBlockExtensionInterface;
+use Smarty_Internal_Template;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Implements smarty {trans}...{/trans} block
+ *
+ * @package ImpressCMS\Core\Extensions\Smarty\Blocks
+ */
+class TransBlock implements SmartyBlockExtensionInterface
+{
+
+	/**
+	 * @var TranslatorInterface
+	 */
+	private $translator;
+
+	/**
+	 * TransVarModifier constructor.
+	 *
+	 * @param TranslatorInterface $translator
+	 */
+	public function __construct(TranslatorInterface $translator) {
+		$this->translator = $translator;
+	}
+
+    /**
+     * @inheritDoc
+     */
+    public function getName(): string {
+        return 'trans';
+    }
+
+	/**
+	 * @inheritDoc
+	 */
+	public function execute(array $params, ?string $content, Smarty_Internal_Template $template, &$repeat) {
+		if (!$repeat && isset($content)) {
+			return $this->translator->trans(
+				trim($content),
+				$params['parameters'] ?? [],
+				$params['domain'] ?? null,
+				$params['locale'] ?? null
+			);
+		}
+	}
+}

--- a/core/Extensions/Smarty/Modifiers/TransVarModifier.php
+++ b/core/Extensions/Smarty/Modifiers/TransVarModifier.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace ImpressCMS\Core\Extensions\Smarty\Modifiers;
+
+use ImpressCMS\Core\Extensions\Smarty\SmartyModifierExtensionInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Trans var modifier (aka filter) similar as twig trans function
+ *
+ * @package ImpressCMS\Core\Extensions\Smarty\Modifiers
+ */
+class TransVarModifier implements SmartyModifierExtensionInterface
+{
+	/**
+	 * @var TranslatorInterface
+	 */
+	private $translator;
+
+	/**
+	 * TransVarModifier constructor.
+	 *
+	 * @param TranslatorInterface $translator
+	 */
+	public function __construct(TranslatorInterface $translator) {
+		$this->translator = $translator;
+	}
+
+	/**
+	 * Executes modifier
+	 *
+	 * @param string $message Message or id string to translate
+	 * @param array $parameters Translation parameters
+	 * @param string|null $domain Translation domain
+	 * @param string|null $locale Locale
+	 *
+	 * @return string
+	 */
+	public function execute($message, array $parameters = [], ?string $domain = null, ?string $locale = null) {
+		return $this->translator->trans($message, $parameters, $domain, $locale);
+	}
+
+    /**
+     * @inheritDoc
+     */
+    public function getName(): string
+    {
+        return 'trans';
+    }
+}

--- a/core/Extensions/Smarty/SmartyBlockExtensionInterface.php
+++ b/core/Extensions/Smarty/SmartyBlockExtensionInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ImpressCMS\Core\Extensions\Smarty;
+
+use Smarty_Internal_Template;
+
+/**
+ * Extension interface for smarty block functions
+ *
+ * @package ImpressCMS\Core\Extensions\Smarty
+ */
+interface SmartyBlockExtensionInterface extends SmartyExtensionInterface {
+
+	/**
+	 * Execute block function
+	 *
+	 * @param array $params Passed params to block
+	 * @param null|string $content Content of template
+	 * @param Smarty_Internal_Template $template Reference to current smarty internal
+	 * @param mixed $repeat Helps work with repeating block processing
+	 *
+	 * @return mixed
+	 */
+	public function execute(array $params, ?string $content, Smarty_Internal_Template $template, &$repeat);
+
+}

--- a/core/Extensions/Smarty/SmartyModifierExtensionInterface.php
+++ b/core/Extensions/Smarty/SmartyModifierExtensionInterface.php
@@ -11,7 +11,7 @@ interface SmartyModifierExtensionInterface extends SmartyExtensionInterface
 {
 
 	/**
-	 * Execute modifier (disabled because there is no way to define it with all possible differnt parameters)
+	 * Execute modifier (disabled because there is no way to define it with all possible different parameters)
 	 * Still function must exist
 	 */
 	//public function execute();

--- a/core/Providers/TranslatorServiceProvider.php
+++ b/core/Providers/TranslatorServiceProvider.php
@@ -124,8 +124,11 @@ class TranslatorServiceProvider extends AbstractServiceProvider implements Servi
 				if ($dirInfo->isDot() || !$dirInfo->isDir()) {
 					continue;
 				}
+				/**
+				 * @var SplFileInfo $fileInfo
+				 */
 				foreach ($this->createTranslationFileIterator($dirInfo) as $fileInfo) {
-					if ($fileInfo->isDir()) {
+					if ($fileInfo->isDir() || $fileInfo->getExtension() === 'tpl') {
 						continue;
 					}
 					yield $this->generateResourceLineForCache($fileInfo, $dirInfo);

--- a/core/View/Template.php
+++ b/core/View/Template.php
@@ -87,6 +87,7 @@ class Template extends SmartyBC
 					 'function' => 'register_function',
 					 'modifier' => 'register_modifier',
 					 'compiler' => 'register_compiler_function',
+			         'block' => 'register_block',
 				 ] as $type => $function) {
 			foreach (icms::getInstance()->get('smarty.' . $type) as $plugin) {
 				$this->$function(

--- a/core/View/Template.php
+++ b/core/View/Template.php
@@ -30,9 +30,9 @@
 /**
  * The templates class that extends Smarty
  *
- * @copyright	http://www.impresscms.org/ The ImpressCMS Project
- * @license	LICENSE.txt
- * @author	modified by UnderDog <underdog@impresscms.org>
+ * @copyright    http://www.impresscms.org/ The ImpressCMS Project
+ * @license    LICENSE.txt
+ * @author    modified by UnderDog <underdog@impresscms.org>
  */
 
 namespace ImpressCMS\Core\View;
@@ -50,9 +50,9 @@ use SmartyException;
 /**
  * Template engine
  *
- * @package	ICMS\View
- * @author	Kazumi Ono 	<onokazu@xoops.org>
- * @copyright	Copyright (c) 2000 XOOPS.org
+ * @package    ICMS\View
+ * @author    Kazumi Ono    <onokazu@xoops.org>
+ * @copyright    Copyright (c) 2000 XOOPS.org
  */
 class Template extends SmartyBC
 {
@@ -69,11 +69,12 @@ class Template extends SmartyBC
 	 */
 	public $currentTheme;
 
-	public function __construct() {
+	public function __construct()
+	{
 		global $icmsConfig, $icmsModule;
 
 		$this->compile_id = $icmsConfig['template_set'] . '-' . $icmsConfig['theme_set'];
-		$this->compile_check = ( (int)$icmsConfig['theme_fromfile'] === 1 );
+		$this->compile_check = ((int)$icmsConfig['theme_fromfile'] === 1);
 
 		parent::__construct();
 
@@ -87,7 +88,7 @@ class Template extends SmartyBC
 					 'function' => 'register_function',
 					 'modifier' => 'register_modifier',
 					 'compiler' => 'register_compiler_function',
-			         'block' => 'register_block',
+					 'block' => 'register_block',
 				 ] as $type => $function) {
 			foreach (icms::getInstance()->get('smarty.' . $type) as $plugin) {
 				$this->$function(
@@ -99,8 +100,8 @@ class Template extends SmartyBC
 
 		if ($icmsConfig['debug_mode']) {
 			$this->debugging_ctrl = 'URL';
-			$groups = (is_object(icms::$user))? icms::$user->getGroups():array(ICMS_GROUP_ANONYMOUS);
-			$moduleid = (isset($icmsModule) && is_object($icmsModule))?$icmsModule->mid:1;
+			$groups = (is_object(icms::$user)) ? icms::$user->getGroups() : array(ICMS_GROUP_ANONYMOUS);
+			$moduleid = (isset($icmsModule) && is_object($icmsModule)) ? $icmsModule->mid : 1;
 			$gperm_handler = icms::handler('icms_member_groupperm');
 			if ((int)$icmsConfig['debug_mode'] === 3 && $gperm_handler->checkRight('enable_debug', $moduleid, $groups)) {
 				$this->debugging = true;
@@ -112,26 +113,26 @@ class Template extends SmartyBC
 
 		$this->assign(
 			[
-			'icms_url' => ICMS_URL,
-			'icms_rootpath' => ICMS_ROOT_PATH,
-			'modules_url' => ICMS_MODULES_URL,
-			'modules_rootpath' => ICMS_MODULES_PATH,
-			'icms_langcode' => _LANGCODE,
-			'icms_langname' => $GLOBALS['icmsConfig']['language'],
-			'icms_charset' => _CHARSET,
-			'icms_version' => ICMS_VERSION_NAME,
-			'icms_upload_url' => ICMS_UPLOAD_URL,
-			'xoops_url' => ICMS_URL,
-			'xoops_rootpath' => ICMS_ROOT_PATH,
-			'xoops_langcode' => _LANGCODE,
-			'xoops_charset' => _CHARSET,
-			'xoops_version' => ICMS_VERSION_NAME,
-			'xoops_upload_url' => ICMS_UPLOAD_URL,
-			'globals' => $GLOBALS
+				'icms_url' => ICMS_URL,
+				'icms_rootpath' => ICMS_ROOT_PATH,
+				'modules_url' => ICMS_MODULES_URL,
+				'modules_rootpath' => ICMS_MODULES_PATH,
+				'icms_langcode' => _LANGCODE,
+				'icms_langname' => $GLOBALS['icmsConfig']['language'],
+				'icms_charset' => _CHARSET,
+				'icms_version' => ICMS_VERSION_NAME,
+				'icms_upload_url' => ICMS_UPLOAD_URL,
+				'xoops_url' => ICMS_URL,
+				'xoops_rootpath' => ICMS_ROOT_PATH,
+				'xoops_langcode' => _LANGCODE,
+				'xoops_charset' => _CHARSET,
+				'xoops_version' => ICMS_VERSION_NAME,
+				'xoops_upload_url' => ICMS_UPLOAD_URL,
+				'globals' => $GLOBALS
 			]
 		);
 
-		$this->registerObject('icms', icms::getInstance(),null,false);
+		$this->registerObject('icms', icms::getInstance(), null, false);
 	}
 
 	/**
@@ -142,7 +143,8 @@ class Template extends SmartyBC
 	 * @return  string            Rendered output if $display was false
 	 * @throws SmartyException
 	 */
-	public function fetchFromData($tplSource, $display = false, $vars = null) {
+	public function fetchFromData($tplSource, $display = false, $vars = null)
+	{
 		if (isset($vars)) {
 			$oldVars = $this->_tpl_vars;
 			$this->assign($vars);
@@ -156,11 +158,12 @@ class Template extends SmartyBC
 	/**
 	 * Touch the resource (file) which means get it to recompile the resource
 	 *
-	 * @param   string  $resourceName	Resource name to touch
+	 * @param string $resourceName Resource name to touch
 	 *
 	 * @return  int
 	 */
-	public function touch($resourceName) {
+	public function touch($resourceName)
+	{
 		return $this->clearCache($resourceName);
 	}
 
@@ -172,9 +175,10 @@ class Template extends SmartyBC
 	 * @return  boolean
 	 * @throws InvalidArgumentException
 	 */
-	public static function template_touch($tpl_id) {
-		$tplFileHandler = & icms::handler('icms_view_template_file');
-		$tplFile = & $tplFileHandler->get($tpl_id);
+	public static function template_touch($tpl_id)
+	{
+		$tplFileHandler = &icms::handler('icms_view_template_file');
+		$tplFile = &$tplFileHandler->get($tpl_id);
 
 		if (!is_object($tplFile)) {
 			return false;
@@ -198,9 +202,10 @@ class Template extends SmartyBC
 	/**
 	 * Clear the module cache
 	 *
-	 * @param   int $mid    Module ID
+	 * @param int $mid Module ID
 	 */
-	public static function template_clear_module_cache($mid) {
+	public static function template_clear_module_cache($mid)
+	{
 		$icms_block_handler = icms::handler('icms_view_block');
 		$block_arr = $icms_block_handler->getByModule($mid);
 		$count = count($block_arr);
@@ -239,7 +244,8 @@ class Template extends SmartyBC
 	 *
 	 * @throws SmartyException
 	 */
-	private function handleDeletedTemplateSet(SmartyException $exception): void {
+	private function handleDeletedTemplateSet(SmartyException $exception): void
+	{
 		$isAdmin = $this->getTemplateVars('icms_isadmin');
 		$themesList = $isAdmin ? ThemeFactory::getAdminThemesList() : ThemeFactory::getThemesList();
 		$configKey = $isAdmin ? 'theme_admin_set' : 'theme_set';


### PR DESCRIPTION
Previously added #801 wasn't accesible from templates. This pull request adds needed for that functionality.

There are two new ways to translate strings in template: function blocks and vars modifiers.

F.e. if I want to translate `_AD_INSTALLEDMODULES` that exists in admin.php I could write it...

....with block function:
```
<{trans domain='admin'}>_AD_INSTALLEDMODULES<{/trans}>
```

...with var modifier:
```
<{"_AD_INSTALLEDMODULES"|trans:[]:'admin'}>
```

Block function supports such attributes:
| Atribute | What it does? | Default value |
|----------|-----------------|----------------|
| parameters | Key/value lists that should be replaced in translated string |  [] |
| domain | Domain from where to get translation string (in most cases same as translation file) | *(system default value)* |
| locale | Translate in specific locale | *(current system locale)* |

Var modifier also supports these attributes, but syntax is a bit different - `trans:PARAMETERS:DOMAIN:LOCALE`