### PR TITLE
Fixed bug when handlers from module separate files cant be loaded

### DIFF
--- a/htdocs/include/functions.php
+++ b/htdocs/include/functions.php
@@ -1589,8 +1589,10 @@ function &icms_getModuleHandler($name = null, $module_dir = null, $module_basena
 		if (class_exists($class)) {
 			$handlers[$module_dir][$name] = new $class(icms::$xoopsDB);
 		} else {
-			if($module_dir != 'system') {
-				$hnd_file = ICMS_ROOT_PATH . "/modules/{$module_dir}/class/{$name}.php";
+			if($module_dir !== 'system') {
+				if (!file_exists($hnd_file = ICMS_ROOT_PATH . "/modules/{$module_dir}/class/". ucfirst(strtolower($name)) ."Handler.php")) {
+					$hnd_file = ICMS_ROOT_PATH . "/modules/{$module_dir}/class/{$name}.php";
+				}
 			} else {
 				$hnd_file = ICMS_ROOT_PATH . "/modules/{$module_dir}/admin/{$name}/class/{$name}.php";
 			}


### PR DESCRIPTION
Some modules like [IsengardBiz/news](https://github.com/IsengardBiz/news) has separated handlers from objects in different files. Current ICMS version prevented such file to be loaded. This should fix that.