### PR TITLE
Added exception handler

### DIFF
--- a/htdocs/libraries/icms/core/Logger.php
+++ b/htdocs/libraries/icms/core/Logger.php
@@ -61,6 +61,7 @@ class icms_core_Logger {
 			$instance = new icms_core_Logger();
 			// Always catch errors, for security reasons
 			set_error_handler( array( $instance, "handleError" ) );
+			set_exception_handler(array($instance, 'handleException'));
 		}
 		return $instance;
 	}
@@ -185,7 +186,33 @@ class icms_core_Logger {
 		if ($this->activated )
 		$this->filters[] = array('name' => $name, 'filtermsg' => (int) $filter_message);
 	}
-    
+
+	/**
+	 * Handle exception
+	 *
+	 * @param Exception $exception
+	 */
+	public function handleException($exception) {
+		icms_loadLanguageFile('core', 'core');
+
+		$errortext = sprintf(_CORE_PAGENOTDISPLAYED, $exception->getMessage());
+		echo $errortext;
+		$trace = true;
+		if ($trace) {
+			echo "<div>Backtrace:<br />";
+			$trace = $exception->getTrace();
+			array_shift( $trace );
+			foreach ( $trace as $step) {
+				if (isset($step['file'])) {
+					echo $this->sanitizePath($step['file']);
+					echo ' (' . $step['line'] . ")\n<br />";
+				}
+			}
+			echo '</div>';
+		}
+		exit();
+	}
+
     /**
 	 * Error handling callback (called by the zend engine)
 	 * @param  string  $errno

--- a/htdocs/libraries/icms/core/Logger.php
+++ b/htdocs/libraries/icms/core/Logger.php
@@ -195,10 +195,16 @@ class icms_core_Logger {
 	public function handleException($exception) {
 		icms_loadLanguageFile('core', 'core');
 
-		$errortext = sprintf(_CORE_PAGENOTDISPLAYED, $exception->getMessage());
-		echo $errortext;
+		$errstr = $exception->getMessage();
 		$trace = true;
+		if (substr($errstr, 0, '8') == 'notrace:') {
+			$trace = false;
+			$errstr = substr($errstr, 8);
+		}
+		echo sprintf(_CORE_PAGENOTDISPLAYED, $errstr);
 		if ($trace) {
+			echo '<br /><div>File: ' . $exception->getFile() . '</div>';
+			echo '<div>Line: ' . $exception->getLine() . '</div>';
 			echo "<div>Backtrace:<br />";
 			$trace = $exception->getTrace();
 			array_shift( $trace );


### PR DESCRIPTION
This will help easier to figure out what a blank page really means.

Example screen:
![image](https://user-images.githubusercontent.com/342641/104133279-3fbf6700-538b-11eb-82b4-b0aaded2eccb.png)

P.S.: syntax exceptions are handled >= 7.0; 5.6 handles most others; If exception happens before logger initialization also would not be handled in such way.