### PR TITLE
Fix "#881 trying to send mails with SMTP auth gives missing smtp class"

### DIFF
--- a/htdocs/libraries/icms/messaging/EmailHandler.php
+++ b/htdocs/libraries/icms/messaging/EmailHandler.php
@@ -43,6 +43,7 @@
  * load the base class
  */
 require_once ICMS_LIBRARIES_PATH . '/phpmailer/class.phpmailer.php';
+require_once ICMS_LIBRARIES_PATH . '/phpmailer/class.smtp.php';
 
 /**
  * Mailer Class.


### PR DESCRIPTION
Fixes #881 

Still for using google mail that could be noth enough - Google is moving to OAUTH and we do not have yet such functionality.