### PR TITLE
CacheClearSetup steps moved to same namespace/path as other steps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -461,7 +461,7 @@
           "setup_step.module.uninstall"
         ]
       },
-      "\\ImpressCMS\\Core\\SetupSteps\\Module\\Install\\CacheClearSetupStep": {
+      "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Install\\CacheClearSetupStep": {
         "tags": [
           "setup_step.module.install"
         ],
@@ -469,7 +469,7 @@
           "cache"
         ]
       },
-      "\\ImpressCMS\\Core\\SetupSteps\\Module\\Uninstall\\CacheClearSetupStep": {
+      "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Uninstall\\CacheClearSetupStep": {
         "tags": [
           "setup_step.module.uninstall"
         ],
@@ -477,7 +477,7 @@
           "cache"
         ]
       },
-      "\\ImpressCMS\\Core\\SetupSteps\\Module\\Update\\CacheClearSetupStep": {
+      "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Update\\CacheClearSetupStep": {
         "tags": [
           "setup_step.module.update"
         ],

--- a/core/Extensions/SetupSteps/Module/Install/CacheClearSetupStep.php
+++ b/core/Extensions/SetupSteps/Module/Install/CacheClearSetupStep.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace ImpressCMS\Core\SetupSteps\Module\Install;
+namespace ImpressCMS\Core\Extensions\SetupSteps\Module\Install;
 
 use Apix\Cache\PsrCache\Pool;
 

--- a/core/Extensions/SetupSteps/Module/Uninstall/CacheClearSetupStep.php
+++ b/core/Extensions/SetupSteps/Module/Uninstall/CacheClearSetupStep.php
@@ -1,9 +1,9 @@
 <?php
 
 
-namespace ImpressCMS\Core\SetupSteps\Module\Uninstall;
+namespace ImpressCMS\Core\Extensions\SetupSteps\Module\Uninstall;
 
-use ImpressCMS\Core\SetupSteps\Module\Install\CacheClearSetupStep as OriginalCacheClearSetupStep;
+use ImpressCMS\Core\Extensions\SetupSteps\Module\Install\CacheClearSetupStep as OriginalCacheClearSetupStep;
 use ImpressCMS\Core\Extensions\SetupSteps\SetupStepInterface;
 
 /**

--- a/core/Extensions/SetupSteps/Module/Update/CacheClearSetupStep.php
+++ b/core/Extensions/SetupSteps/Module/Update/CacheClearSetupStep.php
@@ -1,9 +1,9 @@
 <?php
 
 
-namespace ImpressCMS\Core\SetupSteps\Module\Update;
+namespace ImpressCMS\Core\Extensions\SetupSteps\Module\Update;
 
-use ImpressCMS\Core\SetupSteps\Module\Install\CacheClearSetupStep as OriginalCacheClearSetupStep;
+use ImpressCMS\Core\Extensions\SetupSteps\Module\Install\CacheClearSetupStep as OriginalCacheClearSetupStep;
 use ImpressCMS\Core\Extensions\SetupSteps\SetupStepInterface;
 
 /**


### PR DESCRIPTION
It seems few setup steps where not where others are, this will fix that.