### PR TITLE
Fixed bug when admin menu can't regenerate when module folder is removed before uninstalling

### DIFF
--- a/htdocs/include/cp_functions.php
+++ b/htdocs/include/cp_functions.php
@@ -224,7 +224,14 @@ if (! empty( $_SESSION['redirect_message'] )) {
 			$perm_itens = array();
 			foreach ( $navitem ['menu'] as $item ) {
 				$module = $module_handler->getByDirname($item['dir']);
-				$admin_perm = $moduleperm_handler->checkRight('module_admin', $module->getVar('mid'), icms::$user->getGroups());
+				if (!$module) {
+					continue;
+				}
+				$admin_perm = $moduleperm_handler->checkRight(
+					'module_admin',
+					$module->getVar('mid'),
+					icms::$user->getGroups()
+				);
 				if ($admin_perm) {
 					if ($item['dir'] != 'system') {
 						$perm_itens[] = $item;


### PR DESCRIPTION
From now if that happens such module will be skipped.