### PR TITLE
Fixed bug when there are no editors of type

### DIFF
--- a/core/View/Form/Elements/DHTMLTextAreaElement.php
+++ b/core/View/Form/Elements/DHTMLTextAreaElement.php
@@ -38,6 +38,7 @@ namespace ImpressCMS\Core\View\Form\Elements;
 use ImpressCMS\Core\DataFilter;
 use ImpressCMS\Core\Extensions\Editors\EditorsRegistry;
 use icms;
+use Exception;
 
 /**
  * A textarea with bbcode formatting and smilie buttons

--- a/libraries/icms.php
+++ b/libraries/icms.php
@@ -113,9 +113,9 @@ final class icms extends Container {
 	/**
 	 * Get instance
 	 *
-	 * @return icms|null
+	 * @return icms
 	 */
-	public static function &getInstance()
+	public static function &getInstance(): \icms
 	{
 		static $instance = null;
 		if ($instance === null) {


### PR DESCRIPTION
If there are no editors in system (happens if you use composer 2), system can't find suitable editor.

I didn't have time to test yet but I think it also could help with #1004.