### PR TITLE
Fixed bug when composer.json module describer failed with unreleased modules due release date

### DIFF
--- a/core/Extensions/ExtensionDescriber/Module/ImpressCMSComposerModuleDescriber.php
+++ b/core/Extensions/ExtensionDescriber/Module/ImpressCMSComposerModuleDescriber.php
@@ -59,7 +59,7 @@ class ImpressCMSComposerModuleDescriber implements ExtensionDescriberInterface
 			'iconbig' => $extra['icon']['big'],
 			'image' => $extra['icon']['big'], // for backward compatibilty; image is alias of big icon
 			'author_word' => null, // probably here should be release message could be fetched... but how?
-			'date' => $package->getReleaseDate()->format('Y-m-d'),
+			'date' => $package->getReleaseDate() ? $package->getReleaseDate()->format('Y-m-d') : null,
 			'status' => null, // deprecated - use version string
 			'status_version' => null, // deprecated - use version string
 			'warning' => $extra['warning'] ?? null,


### PR DESCRIPTION
So, after this module info will not crash for modules that doesn't have been yet released.