### PR TITLE
Fixed module submenu counting bug for PHP 8.x

### DIFF
--- a/core/Models/Module.php
+++ b/core/Models/Module.php
@@ -380,7 +380,7 @@ class Module
 				'headermenucount' => count($this->getAdminHeaderMenu()),
 				'submenus' => $submenus,
 				'currentsub' => $currentsub,
-				'submenuscount' => count($submenus)
+				'submenuscount' => $submenus ? count($submenus) : 0,
 			)
 		);
 		$tpl->display('db:admin/system_adm_modulemenu.html');


### PR DESCRIPTION
On PHP 8.x count cant be used only for arrays or something that implements Countable interface. This will fix such issue for submenu.