### PR TITLE
Fixed bug when legacy module crashed due translations constants not loaded at correct time

### DIFF
--- a/core/Controllers/LegacyController.php
+++ b/core/Controllers/LegacyController.php
@@ -53,6 +53,22 @@ class LegacyController
 
 			global $icmsTpl, $xoopsTpl, $xoopsOption, $icmsAdminTpl, $icms_admin_handler;
 			ob_start();
+			
+			// Never PHP needs to have all constants in file defined and this is problem with some older modules that loads a bit later translations
+			// so here is hack to fix this issue - load all language files at once
+			if (version_compare(phpversion(), '8.0', '>=')) {
+				/**
+				 * @var Filesystem $modulesFs
+				 */
+				$modulesFs = \icms::getInstance()->get('filesystem.modules');
+				foreach ((array)$modulesFs->listContents(\icms::$module->dirname . '/language/english/', true) as $file) {
+					if (!is_array($file) || $file['type'] !== 'file' || $file['basename'][0] === '.' || $file['extension'] !== 'php') {
+						continue;
+					}
+					icms_loadLanguageFile(\icms::$module->dirname, $file['filename']);
+				}
+			}
+			
 			require $path;
 			return new Response(
 				200,


### PR DESCRIPTION
Another PHP 8.x related fix