### PR TITLE
Fixed crashing translator when translation folder contains index file

### DIFF
--- a/core/Providers/TranslatorServiceProvider.php
+++ b/core/Providers/TranslatorServiceProvider.php
@@ -128,7 +128,7 @@ class TranslatorServiceProvider extends AbstractServiceProvider implements Servi
 				 * @var SplFileInfo $fileInfo
 				 */
 				foreach ($this->createTranslationFileIterator($dirInfo) as $fileInfo) {
-					if ($fileInfo->isDir() || $fileInfo->getExtension() === 'tpl') {
+					if ($fileInfo->isDir() || in_array(strtolower($fileInfo->getExtension()), ['tpl', 'html', 'htm'], true)) {
 						continue;
 					}
 					yield $this->generateResourceLineForCache($fileInfo, $dirInfo);


### PR DESCRIPTION
Many our modules in translation folder contains *.html files and these files made icms crash when translator is used (because there was no .html files supported translator). Now these files are ignored.