### PR TITLE
Fixes some old class references resolving for some older modules

### DIFF
--- a/include/deprecated_class_aliases.php
+++ b/include/deprecated_class_aliases.php
@@ -372,4 +372,11 @@ return [
 	'icms_Autoloader' => Autoloader::class,
 	'icms_Event' => Event::class,
 	'icms_Utils' => Utils::class,
+	'IcmsPersistableObject' => AbstractExtendedModel::class,
+	'IcmsPersistableObjectHandler' => AbstractExtendedHandler::class,
+	'IcmsPersistableRegistry' => ObjectRegistry::class,
+	'Criteria' => CriteriaItem::class,
+	'IcmsPersistableTable' => Table::class,
+	'IcmsPersistableColumn' => Column::class,
+	'CriteriaCompo' => CriteriaCompo::class,
 ];


### PR DESCRIPTION
It seems there were few class names that were not correctly resolved for some older modules. This fixes that.