### PR TITLE
Add IcmsPersistableController to legacy class resolving map

### DIFF
--- a/include/deprecated_class_aliases.php
+++ b/include/deprecated_class_aliases.php
@@ -375,6 +375,7 @@ return [
 	'IcmsPersistableObject' => AbstractExtendedModel::class,
 	'IcmsPersistableObjectHandler' => AbstractExtendedHandler::class,
 	'IcmsPersistableRegistry' => ObjectRegistry::class,
+	'IcmsPersistableController' => ModelController::class,
 	'Criteria' => CriteriaItem::class,
 	'IcmsPersistableTable' => Table::class,
 	'IcmsPersistableColumn' => Column::class,


### PR DESCRIPTION
This fixes compatibility issue for some old icms modules. 