### PR TITLE
Enable migrations for modules in module installer/updating/removing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -284,6 +284,11 @@
           "setup_step.module.install"
         ]
       },
+      "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Install\\MigrateSetupStep": {
+        "tags": [
+          "setup_step.module.install"
+        ]
+      },
       "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Install\\BlockSetupStep": {
         "tags": [
           "setup_step.module.install"
@@ -324,6 +329,11 @@
           "setup_step.module.update"
         ]
       },
+      "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Update\\MigrateSetupStep": {
+        "tags": [
+          "setup_step.module.update"
+        ]
+      },
       "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Update\\ConfigSetupStep": {
         "tags": [
           "setup_step.module.update"
@@ -352,6 +362,11 @@
       "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Uninstall\\BlockSetupStep": {
         "tags": [
           "setup_step.module.uninstall"
+        ]
+      },
+      "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Uninstall\\MigrateSetupStep": {
+        "tags": [
+          "setup_step.module.uninstalls"
         ]
       },
       "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Uninstall\\CommentsSetupStep": {

--- a/composer.json
+++ b/composer.json
@@ -366,7 +366,7 @@
       },
       "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Uninstall\\MigrateSetupStep": {
         "tags": [
-          "setup_step.module.uninstalls"
+          "setup_step.module.uninstall"
         ]
       },
       "\\ImpressCMS\\Core\\Extensions\\SetupSteps\\Module\\Uninstall\\CommentsSetupStep": {

--- a/core/Extensions/SetupSteps/Module/Install/MigrateSetupStep.php
+++ b/core/Extensions/SetupSteps/Module/Install/MigrateSetupStep.php
@@ -6,6 +6,9 @@ namespace ImpressCMS\Core\Extensions\SetupSteps\Module\Install;
 use ImpressCMS\Core\Extensions\SetupSteps\OutputDecorator;
 use ImpressCMS\Core\Extensions\SetupSteps\SetupStepInterface;
 use ImpressCMS\Core\Models\Module;
+use Phoenix\Command\MigrateCommand;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Input\ArrayInput;
 
 class MigrateSetupStep implements SetupStepInterface
 {
@@ -20,10 +23,10 @@ class MigrateSetupStep implements SetupStepInterface
 			return true;
 		}
 
-		$symfonyConsoleApplication = new \Symfony\Component\Console\Application('icms-setup-action');
+		$symfonyConsoleApplication = new Application('icms-setup-action');
 		$symfonyConsoleApplication->setAutoExit(false);
-		$symfonyConsoleApplication->add(new \Phoenix\Command\MigrateCommand());
-		$symfonyConsoleApplication->run(new \Symfony\Component\Console\Input\ArrayInput([
+		$symfonyConsoleApplication->add(new MigrateCommand());
+		$symfonyConsoleApplication->run(new ArrayInput([
 			'command' => 'migrate',
 			'--dir' => ['module/' . $module->dirname],
 			'--config_type' => 'php',
@@ -38,6 +41,6 @@ class MigrateSetupStep implements SetupStepInterface
 	 */
 	public function getPriority(): int
 	{
-		return 0;
+		return 99;
 	}
 }

--- a/core/Extensions/SetupSteps/Module/Update/MigrateSetupStep.php
+++ b/core/Extensions/SetupSteps/Module/Update/MigrateSetupStep.php
@@ -1,6 +1,5 @@
 <?php
 
-
 namespace ImpressCMS\Core\Extensions\SetupSteps\Module\Update;
 
 use ImpressCMS\Core\Extensions\SetupSteps\Module\Install\MigrateSetupStep as MigrateInstallSetupStep;

--- a/phoenix.php
+++ b/phoenix.php
@@ -4,6 +4,8 @@
  * This file is used for configuring migrations service
  */
 
+use ImpressCMS\Core\Models\ModuleHandler;
+
 define('ICMS_MIGRATION_MODE', true);
 
 require_once __DIR__ . '/mainfile.php';
@@ -11,14 +13,14 @@ require_once __DIR__ . '/mainfile.php';
 /**
  * @var icms_db_Connection $databaseConnection
  */
-$databaseConnection = \icms::getInstance()->get('db-connection-1');
+$databaseConnection = icms::getInstance()->get('db-connection-1');
 
 /**
  * Finds module paths that contains migrations
  * (if module has folder called 'migrations' that means module has some migrations)
  */
 $modulesMigrations = [];
-foreach(icms_module_Handler::getAvailable() as $dirName) {
+foreach (ModuleHandler::getAvailable() as $dirName) {
 	$path = ICMS_MODULES_PATH . DIRECTORY_SEPARATOR . $dirName . DIRECTORY_SEPARATOR . 'migrations';
 	if (!file_exists($path) || !is_dir($path)) {
 		continue;


### PR DESCRIPTION
Previously migrations worked only for core. This adds also migrations to modules.