### PR TITLE
Added posibility to specify default block weight, position and visibility

### DIFF
--- a/core/Extensions/SetupSteps/Module/Install/BlockSetupStep.php
+++ b/core/Extensions/SetupSteps/Module/Install/BlockSetupStep.php
@@ -215,23 +215,10 @@ class BlockSetupStep implements SetupStepInterface, ContainerAwareInterface
 	 */
 	protected function createNewBlock(array $blockInfo, Module $module, $key, string $template): Block
 	{
-		static $blockPositions = null;
-
 		/**
 		 * @var BlockHandler $blockHandler
 		 */
 		$blockHandler = icms::handler('icms_view_block');
-
-		if ($blockPositions === null) {
-			$blockPositions = array_flip(
-				$blockHandler->getBlockPositions()
-			);
-		}
-
-		$side = 1;
-		if (isset($blockInfo['position'], $blockPositions[$blockInfo['position']])) {
-			$side = $blockPositions[$blockInfo['position']];
-		}
 
 		/**
 		 * @var Block $newBlock
@@ -243,7 +230,7 @@ class BlockSetupStep implements SetupStepInterface, ContainerAwareInterface
 		$newBlock->name = $this->getTranslatedName($blockInfo['name']);
 		$newBlock->title = $this->getTranslatedName($blockInfo['name']);
 		$newBlock->content = '';
-		$newBlock->side = $side;
+		$newBlock->side = isset($blockInfo['position']) ? $this->getBlockPositionIdByName($blockInfo['position']) : 1;
 		$newBlock->weight = $blockInfo['weight'] ?? 0;
 		$newBlock->visible = isset($blockInfo['visible']) && $blockInfo['visible'];
 		$newBlock->block_type = ($module->dirname === 'system') ? Block::BLOCK_TYPE_SYSTEM : Block::BLOCK_TYPE_MODULE;
@@ -258,5 +245,30 @@ class BlockSetupStep implements SetupStepInterface, ContainerAwareInterface
 		$newBlock->last_modified = time();
 
 		return $newBlock;
+	}
+
+	/**
+	 * Get block position ID by name
+	 *
+	 * @param string $positionName Block position name
+	 *
+	 * @return int
+	 */
+	private function getBlockPositionIdByName(string $positionName): int
+	{
+		static $blockPositions = null;
+
+		/**
+		 * @var BlockHandler $blockHandler
+		 */
+		$blockHandler = icms::handler('icms_view_block');
+
+		if ($blockPositions === null) {
+			$blockPositions = array_flip(
+				$blockHandler->getBlockPositions()
+			);
+		}
+
+		return $blockPositions[$positionName] ?? 1;
 	}
 }

--- a/core/Extensions/SetupSteps/Module/Install/BlockSetupStep.php
+++ b/core/Extensions/SetupSteps/Module/Install/BlockSetupStep.php
@@ -8,6 +8,7 @@ use icms;
 use ImpressCMS\Core\Extensions\SetupSteps\OutputDecorator;
 use ImpressCMS\Core\Extensions\SetupSteps\SetupStepInterface;
 use ImpressCMS\Core\Models\Block;
+use ImpressCMS\Core\Models\BlockHandler;
 use ImpressCMS\Core\Models\Module;
 use ImpressCMS\Core\Models\TemplateFile;
 use ImpressCMS\Core\View\Template;
@@ -30,13 +31,12 @@ class BlockSetupStep implements SetupStepInterface, ContainerAwareInterface
 			$output->info(_MD_AM_BLOCKS_ADDING);
 			$output->incrIndent();
 			$dirname = $module->dirname;
-			$newmid = $module->mid;
-			$handler = icms::handler('icms_view_block');
+
 			foreach ($blocks as $blockkey => $block) {
 				if (!isset($block['file'], $block['show_func'])) {
 					continue;
 				}
-				$options = !empty($block['options']) ? trim($block['options']) : '';
+
 				$template = '';
 				if ((isset($block['template']) && trim($block['template']))) {
 					$content = $this->readTemplate($dirname, $block['template']);
@@ -46,29 +46,8 @@ class BlockSetupStep implements SetupStepInterface, ContainerAwareInterface
 				} else {
 					$template = trim($block['template']);
 				}
-				/**
-				 * @var Block $newBlock
-				 */
-				$newBlock = $handler->create();
-				$newBlock->mid = $newmid;
-				$newBlock->func_num = $blockkey;
-				$newBlock->options = $options;
-				$newBlock->name = $this->getTranslatedName($block['name']);
-				$newBlock->title = $this->getTranslatedName($block['name']);
-				$newBlock->content = '';
-				$newBlock->side = 1;
-				$newBlock->weight = 0;
-				$newBlock->visible = 0;
-				$newBlock->block_type = Block::BLOCK_TYPE_MODULE;
-				$newBlock->c_type = Block::CONTENT_TYPE_HTML;
-				$newBlock->isactive = 1;
-				$newBlock->dirname = $dirname;
-				$newBlock->func_file = $block['file'];
-				$newBlock->show_func = $block['show_func'];
-				$newBlock->edit_func = isset($block['edit_func']) ? trim($block['edit_func']) : '';
-				$newBlock->template = $template;
-				$newBlock->bcachetime = 0;
-				$newBlock->last_modified = time();
+
+				$newBlock = $this->createNewBlock($block, $module, $blockkey, $template);
 
 				if (!$newBlock->store()) {
 					$output->error(_MD_AM_BLOCKS_ADD_FAIL, $this->getTranslatedName($block['name']));
@@ -222,5 +201,54 @@ class BlockSetupStep implements SetupStepInterface, ContainerAwareInterface
 	public function getPriority(): int
 	{
 		return 1;
+	}
+
+	protected function createNewBlock(array $blockInfo, Module $module, $key, string $template)
+	{
+		static $blockPositions = null;
+
+		/**
+		 * @var BlockHandler $blockHandler
+		 */
+		$blockHandler = icms::handler('icms_view_block');
+
+		if ($blockPositions === null) {
+			$blockPositions = array_flip(
+				$blockHandler->getBlockPositions()
+			);
+		}
+
+		$side = 1;
+		if (isset($blockInfo['position'], $blockPositions[$blockInfo['position']])) {
+			$side = $blockPositions[$blockInfo['position']];
+		}
+
+		$options = !empty($block['options']) ? trim($block['options']) : '';
+
+		/**
+		 * @var Block $newBlock
+		 */
+		$newBlock = $blockHandler->create();
+		$newBlock->mid = $module->mid;
+		$newBlock->func_num = $key;
+		$newBlock->options = $options;
+		$newBlock->name = $this->getTranslatedName($blockInfo['name']);
+		$newBlock->title = $this->getTranslatedName($blockInfo['name']);
+		$newBlock->content = '';
+		$newBlock->side = $side;
+		$newBlock->weight = $blockInfo['weight'] ?? 0;
+		$newBlock->visible = isset($blockInfo['visible']) && $blockInfo['visible'];
+		$newBlock->block_type = ($module->dirname === 'system') ? Block::BLOCK_TYPE_SYSTEM : Block::BLOCK_TYPE_MODULE;
+		$newBlock->c_type = Block::CONTENT_TYPE_HTML;
+		$newBlock->isactive = 1;
+		$newBlock->dirname = $module->dirname;
+		$newBlock->func_file = $blockInfo['file'];
+		$newBlock->show_func = $blockInfo['show_func'];
+		$newBlock->edit_func = isset($blockInfo['edit_func']) ? trim($blockInfo['edit_func']) : '';
+		$newBlock->template = $template;
+		$newBlock->bcachetime = 0;
+		$newBlock->last_modified = time();
+
+		return $newBlock;
 	}
 }

--- a/core/Extensions/SetupSteps/Module/Install/BlockSetupStep.php
+++ b/core/Extensions/SetupSteps/Module/Install/BlockSetupStep.php
@@ -203,7 +203,17 @@ class BlockSetupStep implements SetupStepInterface, ContainerAwareInterface
 		return 1;
 	}
 
-	protected function createNewBlock(array $blockInfo, Module $module, $key, string $template)
+	/**
+	 * Creates new block
+	 *
+	 * @param array $blockInfo Block info
+	 * @param Module $module Module where block belongs
+	 * @param mixed $key Key in module info for this block
+	 * @param string $template Template for the block
+	 *
+	 * @return Block
+	 */
+	protected function createNewBlock(array $blockInfo, Module $module, $key, string $template): Block
 	{
 		static $blockPositions = null;
 
@@ -223,15 +233,13 @@ class BlockSetupStep implements SetupStepInterface, ContainerAwareInterface
 			$side = $blockPositions[$blockInfo['position']];
 		}
 
-		$options = !empty($block['options']) ? trim($block['options']) : '';
-
 		/**
 		 * @var Block $newBlock
 		 */
 		$newBlock = $blockHandler->create();
 		$newBlock->mid = $module->mid;
 		$newBlock->func_num = $key;
-		$newBlock->options = $options;
+		$newBlock->options = !empty($blockInfo['options']) ? trim($blockInfo['options']) : '';
 		$newBlock->name = $this->getTranslatedName($blockInfo['name']);
 		$newBlock->title = $this->getTranslatedName($blockInfo['name']);
 		$newBlock->content = '';

--- a/core/Extensions/SetupSteps/Module/Update/BlocksSetupStep.php
+++ b/core/Extensions/SetupSteps/Module/Update/BlocksSetupStep.php
@@ -7,7 +7,6 @@ use icms;
 use ImpressCMS\Core\Database\DatabaseConnection;
 use ImpressCMS\Core\Extensions\SetupSteps\Module\Install\BlockSetupStep as InstallBlockSetupStep;
 use ImpressCMS\Core\Extensions\SetupSteps\OutputDecorator;
-use ImpressCMS\Core\Models\Block;
 use ImpressCMS\Core\Models\BlockHandler;
 use ImpressCMS\Core\Models\Module;
 use ImpressCMS\Core\Models\TemplateFileHandler;
@@ -132,29 +131,7 @@ class BlocksSetupStep extends InstallBlockSetupStep
 					}
 
 					if ($fcount === 0) {
-						/**
-						 * @var Block $newBlock
-						 */
-						$newBlock = $newBlocksHandler->create();
-						$newBlock->mid = $module->mid;
-						$newBlock->func_num = $i;
-						$newBlock->options = $options;
-						$newBlock->name = $this->getTranslatedName($block['name']);
-						$newBlock->title = $this->getTranslatedName($block['name']);
-						$newBlock->content = '';
-						$newBlock->side = 1;
-						$newBlock->weight = 0;
-						$newBlock->visible = 0;
-						$newBlock->block_type = Block::BLOCK_TYPE_MODULE;
-						$newBlock->c_type = Block::CONTENT_TYPE_HTML;
-						$newBlock->isactive = 1;
-						$newBlock->dirname = $module->dirname;
-						$newBlock->func_file = $block['file'];
-						$newBlock->show_func = $block['show_func'];
-						$newBlock->edit_func = $editfunc;
-						$newBlock->template = $template;
-						$newBlock->bcachetime = 0;
-						$newBlock->last_modified = time();
+						$newBlock = $this->createNewBlock($block, $module, $i, $template);
 
 						if (!$newBlock->store()) {
 							$output->error(_MD_AM_CREATE_FAIL, $this->getTranslatedName($block['name']));

--- a/migrations/20191230145417_add_initial_data.php
+++ b/migrations/20191230145417_add_initial_data.php
@@ -1,6 +1,7 @@
 <?php
 
 use ImpressCMS\Core\Database\DatabaseConnection;
+use ImpressCMS\Core\Models\Block;
 use Phoenix\Migration\AbstractMigration;
 
 class AddInitialData extends AbstractMigration
@@ -397,15 +398,15 @@ class AddInitialData extends AbstractMigration
 				} else {
 					$visible = 0;
 				}
-				if ($newblock['template'] == 'system_block_search.html') {
+				if ($newblock['template'] === 'system_block_search.html') {
 					$canvaspos = 2;
-				} elseif ($newblock['template'] == 'system_block_socialbookmark.html') {
+				} elseif ($newblock['template'] === 'system_block_socialbookmark.html') {
 					$canvaspos = 7;
-				} elseif ($newblock['template'] == 'system_admin_block_warnings.html') {
+				} elseif ($newblock['template'] === 'system_admin_block_warnings.html') {
 					$canvaspos = 12;
-				} elseif ($newblock['template'] == 'system_admin_block_cp.html') {
+				} elseif ($newblock['template'] === 'system_admin_block_cp.html') {
 					$canvaspos = 11;
-				} elseif ($newblock['template'] == 'system_admin_block_modules.html') {
+				} elseif ($newblock['template'] === 'system_admin_block_modules.html') {
 					$canvaspos = 13;
 				} elseif (in_array($newblock['template'], ['system_block_online.html', 'system_block_waiting.html'])) {
 					$canvaspos = 9;
@@ -428,8 +429,8 @@ class AddInitialData extends AbstractMigration
 						'side' => $canvaspos,
 						'weight' => 0,
 						'visible' => $visible,
-						'block_type' => 'S',
-						'c_type' => 'H',
+						'block_type' => Block::BLOCK_TYPE_SYSTEM,
+						'c_type' => Block::CONTENT_TYPE_HTML,
 						'isactive' => 1,
 						'dirname' => 'system',
 						'func_file' => $newblock['file'],


### PR DESCRIPTION
From now is possible to specify default blocks positions, weights and visibilities. 

f.e."
```yaml
    "blocks": {
      "1": {
        "file": "system_blocks.php",
        "name": "_MI_SYSTEM_BNAME2",
        "description": "",
        "show_func": "b_system_user_show",
        "edit_func": "b_system_user_edit",
        "options": "0",
        "template": "system_block_user.html",
        "visible": true //  this block will be made as default visible
        "position": "canvas_right", // this block if available will be visible at canvas_right block position
        "weight": 999 // this block will have 999 weight when sorting blocks
      }
    }
```