### PR TITLE
Use phoenix mini container functionality to share some custom functions between all migrations

### DIFF
--- a/core/Database/AbstractDatabaseMigration.php
+++ b/core/Database/AbstractDatabaseMigration.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace ImpressCMS\Core\Database;
+
+use Phoenix\Database\Adapter\AdapterInterface;
+use Phoenix\Migration\AbstractMigration;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Extends abstract phoenix migration with some needed ImpressCMS functionality
+ */
+abstract class AbstractDatabaseMigration extends AbstractMigration
+{
+
+	/**
+	 * @var ContainerInterface
+	 */
+	private $container;
+
+	/**
+	 * Migration constructor
+	 *
+	 * @param AdapterInterface $adapter
+	 * @param ContainerInterface $container
+	 */
+	public function __construct(AdapterInterface $adapter, ContainerInterface $container)
+	{
+		$this->container = $container;
+
+		parent::__construct($adapter);
+	}
+
+	/**
+	 * Prefix a table
+	 *
+	 * @param string $table Table to prefix
+	 *
+	 * @return string
+	 */
+	protected function prefix(string $table): string {
+		return $this->getDatabaseConnection()->prefix($table);
+	}
+
+	/**
+	 * Gets native database connection instance
+	 *
+	 * @param int $no Database connection number
+	 *
+	 * @return DatabaseConnectionInterface
+	 */
+	protected function getDatabaseConnection(int $no = 1): DatabaseConnectionInterface {
+		return $this->container->get('db-connection-'.$no);
+	}
+
+	/**
+	 * Get container
+	 *
+	 * @return ContainerInterface
+	 */
+	protected function getContainer(): ContainerInterface {
+		return $this->container;
+	}
+}

--- a/migrations/20191230123706_initialization.php
+++ b/migrations/20191230123706_initialization.php
@@ -1,21 +1,9 @@
 <?php
 
-use Phoenix\Migration\AbstractMigration;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 
-class Initialization extends AbstractMigration
+class Initialization extends AbstractDatabaseMigration
 {
-
-	/**
-	 * Prefix table
-	 *
-	 * @param string $table Table to prefix
-	 *
-	 * @return string
-	 */
-	private function prefix(string $table): string {
-		return \icms::getInstance()->get('db-connection-1')->prefix($table);
-	}
-
 	/**
 	 * Does actions when migrating up
 	 */

--- a/migrations/20191230145417_add_initial_data.php
+++ b/migrations/20191230145417_add_initial_data.php
@@ -1,10 +1,10 @@
 <?php
 
-use ImpressCMS\Core\Database\DatabaseConnection;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 use ImpressCMS\Core\Models\Block;
 use Phoenix\Migration\AbstractMigration;
 
-class AddInitialData extends AbstractMigration
+class AddInitialData extends AbstractDatabaseMigration
 {
 	protected function up(): void
 	{
@@ -30,12 +30,8 @@ class AddInitialData extends AbstractMigration
 			throw new RuntimeException('ICMS_URL must be not empty');
 		}
 
-		/**
-		 * @var DatabaseConnection $dbm
-		 */
-		$dbm = icms::getInstance()->get('db-connection-1');
-		$usersTable = $dbm->prefix('users');
-		if ($this->tableExists($usersTable) && ((int)($dbm->fetchCol('SELECT COUNT(*) FROM `' . $usersTable . '`;')[0]) > 0)) {
+		$usersTable = $this->prefix('users');
+		if ($this->tableExists($usersTable) && ((int)($this->getDatabaseConnection()->fetchCol('SELECT COUNT(*) FROM `' . $usersTable . '`;')[0]) > 0)) {
 			// skipping this migration if at least one user is found
 			return;
 		}

--- a/migrations/20191230233945_setup_block_links.php
+++ b/migrations/20191230233945_setup_block_links.php
@@ -1,23 +1,21 @@
 <?php
 
-use Phoenix\Migration\AbstractMigration;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 
-class SetupBlockLinks extends AbstractMigration
+class SetupBlockLinks extends AbstractDatabaseMigration
 {
+
     protected function up(): void
     {
-		/**
-		 * @var \icms_db_Connection $dbm
-		 */
-		$dbm = \icms::getInstance()->get('db-connection-1');
+		$dbm = $this->getDatabaseConnection();
 
-		if (((int)($dbm->fetchCol('SELECT COUNT(*) FROM `' . $dbm->prefix('block_module_link') . '`;')[0]) > 0)) {
+		if (((int)($dbm->fetchCol('SELECT COUNT(*) FROM `' . $this->prefix('block_module_link') . '`;')[0]) > 0)) {
 			// skipping this migration if at least one block_module_link is found
 			return;
 		}
 
 		// data for table 'block_module_link'
-		$sql = 'SELECT bid, side, template FROM ' . $dbm->prefix('newblocks');
+		$sql = 'SELECT bid, side, template FROM ' . $this->prefix('newblocks');
 		$result = $dbm->query($sql);
 
 		$links = [];
@@ -44,7 +42,10 @@ class SetupBlockLinks extends AbstractMigration
 			}
 		}
 
-		$this->insert($dbm->prefix('block_module_link'), $links);
+		$this->insert(
+			$this->prefix('block_module_link'),
+			$links
+		);
     }
 
     protected function down(): void

--- a/migrations/20200125164107_update_config_for_use_with_monolog.php
+++ b/migrations/20200125164107_update_config_for_use_with_monolog.php
@@ -1,8 +1,8 @@
 <?php
 
-use Phoenix\Migration\AbstractMigration;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 
-class UpdateConfigForUseWithMonolog extends AbstractMigration
+class UpdateConfigForUseWithMonolog extends AbstractDatabaseMigration
 {
     protected function up(): void
     {
@@ -52,15 +52,4 @@ class UpdateConfigForUseWithMonolog extends AbstractMigration
 			]
 		);
     }
-
-	/**
-	 * Prefix table
-	 *
-	 * @param string $table Table to prefix
-	 *
-	 * @return string
-	 */
-	private function prefix(string $table): string {
-		return \icms::getInstance()->get('db-connection-1')->prefix($table);
-	}
 }

--- a/migrations/20200322181415_change_names_for_auto_task_systems_in_config.php
+++ b/migrations/20200322181415_change_names_for_auto_task_systems_in_config.php
@@ -1,8 +1,8 @@
 <?php
 
-use Phoenix\Migration\AbstractMigration;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 
-class ChangeNamesForAutoTaskSystemsInConfig extends AbstractMigration
+class ChangeNamesForAutoTaskSystemsInConfig extends AbstractDatabaseMigration
 {
 	protected function up(): void
 	{
@@ -70,17 +70,5 @@ class ChangeNamesForAutoTaskSystemsInConfig extends AbstractMigration
 				'conf_value' => 'IcmsAutoTasksCron'
 			]
 		);
-	}
-
-	/**
-	 * Prefix table
-	 *
-	 * @param string $table Table to prefix
-	 *
-	 * @return string
-	 */
-	private function prefix(string $table): string
-	{
-		return \icms::getInstance()->get('db-connection-1')->prefix($table);
 	}
 }

--- a/migrations/20200803205508_remove_use_custom_redirection_config_option.php
+++ b/migrations/20200803205508_remove_use_custom_redirection_config_option.php
@@ -1,8 +1,8 @@
 <?php
 
-use Phoenix\Migration\AbstractMigration;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 
-class RemoveUseCustomRedirectionConfigOption extends AbstractMigration
+class RemoveUseCustomRedirectionConfigOption extends AbstractDatabaseMigration
 {
     protected function up(): void
     {
@@ -51,16 +51,4 @@ class RemoveUseCustomRedirectionConfigOption extends AbstractMigration
 			]
 		);
     }
-
-	/**
-	 * Prefix table
-	 *
-	 * @param string $table Table to prefix
-	 *
-	 * @return string
-	 */
-	private function prefix(string $table): string
-	{
-		return \icms::getInstance()->get('db-connection-1')->prefix($table);
-	}
 }

--- a/migrations/20200806213927_convert_all_textsanitizers_contents_to_h_t_m_l.php
+++ b/migrations/20200806213927_convert_all_textsanitizers_contents_to_h_t_m_l.php
@@ -1,8 +1,9 @@
 <?php
 
-use Phoenix\Migration\AbstractMigration;
+use Imponeer\Database\Criteria\CriteriaItem;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 
-class ConvertAllTextsanitizersContentsToHTML extends AbstractMigration
+class ConvertAllTextsanitizersContentsToHTML extends AbstractDatabaseMigration
 {
 	protected function up(): void
 	{
@@ -115,7 +116,7 @@ class ConvertAllTextsanitizersContentsToHTML extends AbstractMigration
 				return $text;
 			}
 			$userHandler = & icms::handler('icms_member');
-			$criteria = new icms_db_criteria_Item('uname', $text);
+			$criteria = new CriteriaItem('uname', $text);
 			$userId = $userHandler->getUsers($criteria);
 			if (!$userId) {
 				return $prefix . "@" . $text;
@@ -296,13 +297,10 @@ class ConvertAllTextsanitizersContentsToHTML extends AbstractMigration
 	 */
 	private function getAllTablesNames(): array
 	{
-		/**
-		 * @var icms_db_Connection $db
-		 */
-		$db = icms::getInstance()->get('db-connection-1');
+		$db = $this->getDatabaseConnection();
 
 		$query = $db->prepareWithValues('SHOW TABLES LIKE :rule;', [
-			'rule' => $db->prefix('') . '%'
+			'rule' => $this->prefix('') . '%'
 		]);
 		$query->execute();
 		return $query->fetchAll(PDO::FETCH_COLUMN);

--- a/migrations/20200806214630_remove_settings_to_make_possible_to_use_old_style_d_h_t_m_l_editor.php
+++ b/migrations/20200806214630_remove_settings_to_make_possible_to_use_old_style_d_h_t_m_l_editor.php
@@ -1,9 +1,9 @@
 <?php
 
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 use ImpressCMS\Core\Extensions\Editors\EditorsRegistry;
-use Phoenix\Migration\AbstractMigration;
 
-class RemoveSettingsToMakePossibleToUseOldStyleDHTMLEditor extends AbstractMigration
+class RemoveSettingsToMakePossibleToUseOldStyleDHTMLEditor extends AbstractDatabaseMigration
 {
     protected function up(): void
     {
@@ -22,16 +22,16 @@ class RemoveSettingsToMakePossibleToUseOldStyleDHTMLEditor extends AbstractMigra
 			]
 		);
 
-		if (!icms::getInstance()->has('\\' . EditorsRegistry::class)) {
+		if (!$this->getContainer()->has('\\' . EditorsRegistry::class)) {
 			icms::getInstance()->boot(false);
 		}
 
 		/**
 		 * @var EditorsRegistry $editorRegistry
 		 */
-		$editorRegistry = icms::getInstance()->get('\\' . EditorsRegistry::class);
+		$editorRegistry = $this->getContainer()->get('\\' . EditorsRegistry::class);
 
-		icms::getInstance()->get('cache')->clear();
+		$this->getContainer()->get('cache')->clear();
 
 		$this->update(
 			$this->prefix('config'),
@@ -80,16 +80,4 @@ class RemoveSettingsToMakePossibleToUseOldStyleDHTMLEditor extends AbstractMigra
 		);
 		// We can't rollback default editor, so we doing here nothing about that
     }
-
-	/**
-	 * Prefix table
-	 *
-	 * @param string $table Table to prefix
-	 *
-	 * @return string
-	 */
-	private function prefix(string $table): string
-	{
-		return icms::getInstance()->get('db-connection-1')->prefix($table);
-	}
 }

--- a/migrations/20200807225033_remove_use_w_y_s_i_w_y_g_editor_right.php
+++ b/migrations/20200807225033_remove_use_w_y_s_i_w_y_g_editor_right.php
@@ -1,8 +1,8 @@
 <?php
 
-use Phoenix\Migration\AbstractMigration;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 
-class RemoveUseWYSIWYGEditorRight extends AbstractMigration
+class RemoveUseWYSIWYGEditorRight extends AbstractDatabaseMigration
 {
     protected function up(): void
     {
@@ -26,16 +26,4 @@ class RemoveUseWYSIWYGEditorRight extends AbstractMigration
 			]
 		);
     }
-
-	/**
-	 * Prefix table
-	 *
-	 * @param string $table Table to prefix
-	 *
-	 * @return string
-	 */
-	private function prefix(string $table): string
-	{
-		return \icms::getInstance()->get('db-connection-1')->prefix($table);
-	}
 }

--- a/migrations/20200808234213_remove_mime_type_editing.php
+++ b/migrations/20200808234213_remove_mime_type_editing.php
@@ -1,8 +1,8 @@
 <?php
 
-use Phoenix\Migration\AbstractMigration;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 
-class RemoveMimeTypeEditing extends AbstractMigration
+class RemoveMimeTypeEditing extends AbstractDatabaseMigration
 {
 	protected function up(): void
 	{
@@ -892,17 +892,5 @@ class RemoveMimeTypeEditing extends AbstractMigration
 					'dirname' => '',
 				],
 			]);
-	}
-
-	/**
-	 * Prefix table
-	 *
-	 * @param string $table Table to prefix
-	 *
-	 * @return string
-	 */
-	private function prefix(string $table): string
-	{
-		return \icms::getInstance()->get('db-connection-1')->prefix($table);
 	}
 }

--- a/migrations/20200809205407_add_encrypt_cookies_settings_option.php
+++ b/migrations/20200809205407_add_encrypt_cookies_settings_option.php
@@ -1,8 +1,8 @@
 <?php
 
-use Phoenix\Migration\AbstractMigration;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 
-class AddEncryptCookiesSettingsOption extends AbstractMigration
+class AddEncryptCookiesSettingsOption extends AbstractDatabaseMigration
 {
 	protected function up(): void
 	{
@@ -34,17 +34,5 @@ class AddEncryptCookiesSettingsOption extends AbstractMigration
 				'conf_name' => 'encrypt_cookies'
 			]
 		);
-	}
-
-	/**
-	 * Prefix table
-	 *
-	 * @param string $table Table to prefix
-	 *
-	 * @return string
-	 */
-	private function prefix(string $table): string
-	{
-		return \icms::getInstance()->get('db-connection-1')->prefix($table);
 	}
 }

--- a/migrations/20200821223712_remove_old_messangers_from_user_if_exists.php
+++ b/migrations/20200821223712_remove_old_messangers_from_user_if_exists.php
@@ -1,8 +1,8 @@
 <?php
 
-use Phoenix\Migration\AbstractMigration;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 
-class RemoveOldMessangersFromUserIfExists extends AbstractMigration
+class RemoveOldMessangersFromUserIfExists extends AbstractDatabaseMigration
 {
     protected function up(): void
     {
@@ -35,16 +35,4 @@ class RemoveOldMessangersFromUserIfExists extends AbstractMigration
 			sprintf('ALTER TABLE %s ADD COLUMN `user_icq` varchar(15) NOT NULL default \'\'', $this->prefix('users'))
 		);
     }
-
-	/**
-	 * Prefix table
-	 *
-	 * @param string $table Table to prefix
-	 *
-	 * @return string
-	 */
-	private function prefix(string $table): string
-	{
-		return \icms::getInstance()->get('db-connection-1')->prefix($table);
-	}
 }

--- a/migrations/20200821235126_remove_open_i_d_field_from_config.php
+++ b/migrations/20200821235126_remove_open_i_d_field_from_config.php
@@ -1,8 +1,8 @@
 <?php
 
-use Phoenix\Migration\AbstractMigration;
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 
-class RemoveOpenIDFieldFromConfig extends AbstractMigration
+class RemoveOpenIDFieldFromConfig extends AbstractDatabaseMigration
 {
     protected function up(): void
     {
@@ -43,16 +43,4 @@ class RemoveOpenIDFieldFromConfig extends AbstractMigration
 			'conf_order' => 1
 		]);
     }
-
-	/**
-	 * Prefix table
-	 *
-	 * @param string $table Table to prefix
-	 *
-	 * @return string
-	 */
-	private function prefix(string $table): string
-	{
-		return \icms::getInstance()->get('db-connection-1')->prefix($table);
-	}
 }

--- a/migrations/20210104224612_add_session_extension_settings_option.php
+++ b/migrations/20210104224612_add_session_extension_settings_option.php
@@ -1,9 +1,9 @@
 <?php
 
+use ImpressCMS\Core\Database\AbstractDatabaseMigration;
 use ImpressCMS\Core\Facades\Config;
-use Phoenix\Migration\AbstractMigration;
 
-class AddSessionExtensionSettingsOption extends AbstractMigration
+class AddSessionExtensionSettingsOption extends AbstractDatabaseMigration
 {
     protected function up(): void
     {
@@ -40,16 +40,4 @@ class AddSessionExtensionSettingsOption extends AbstractMigration
 			'UPDATE ' . $this->prefix('config') . ' SET conf_order = conf_order - 1 WHERE conf_order > 21'
 		);
     }
-
-	/**
-	 * Prefix table
-	 *
-	 * @param string $table Table to prefix
-	 *
-	 * @return string
-	 */
-	private function prefix(string $table): string
-	{
-		return icms::getInstance()->get('db-connection-1')->prefix($table);
-	}
 }

--- a/phoenix.php
+++ b/phoenix.php
@@ -4,14 +4,16 @@
  * This file is used for configuring migrations service
  */
 
+use ImpressCMS\Core\Database\DatabaseConnection;
 use ImpressCMS\Core\Models\ModuleHandler;
+use Psr\Container\ContainerInterface;
 
 define('ICMS_MIGRATION_MODE', true);
 
 require_once __DIR__ . '/mainfile.php';
 
 /**
- * @var icms_db_Connection $databaseConnection
+ * @var DatabaseConnection $databaseConnection
  */
 $databaseConnection = icms::getInstance()->get('db-connection-1');
 
@@ -43,6 +45,9 @@ return [
 			'db_name' => env('DB_NAME', 'impresscms'),
 			'charset' => env('DB_CHARSET', 'utf8'),
 		],
+	],
+	'dependencies' => [
+		ContainerInterface::class => icms::getInstance(),
 	],
 	'default_environment ' => 'local',
 ];


### PR DESCRIPTION
With this is possible to use prefix and container in all migrations without extra hacks.