### PR TITLE
Thrust required composer plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -505,6 +505,11 @@
     "bin-dir": "bin",
     "platform": {
       "php": "7.3.0"
+    },
+    "allow-plugins": {
+      "0.0.0/composer-include-files": true,
+      "typo3/class-alias-loader": true,
+      "impresscms/composer-addon-installer-plugin": true
     }
   },
   "scripts": {


### PR DESCRIPTION
Never composer needs to thrust plugins before using. This will fix that by adding required plugins to `composer.json`.