### PR TITLE
Making sure protector gets installed during the site installation

### DIFF
--- a/htdocs/install/page_modulesinstall.php
+++ b/htdocs/install/page_modulesinstall.php
@@ -67,7 +67,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 		}
 		//Install protector module by default if found.
 		//TODO: Insert Protector installation - leads to blank page as it is now.
-			if (file_exists(ICMS_ROOT_PATH . '/modules/protector/xoops_version.php')) {
+			if (file_exists(ICMS_ROOT_PATH . '/modules/protector/icms_version.php')) {
 				$content .= xoops_module_install('protector');
 				/*        	include_once "./class/mainfilemanager.php";
                  $mm = new mainfile_manager("../mainfile.php");


### PR DESCRIPTION
Install step was looking for xoops_version instead of icms_version.