### PR TITLE
Fix for information displayed in protector admin and debug console

### DIFF
--- a/htdocs/install/modules/protector/trust_path/modules/protector/admin/index.php
+++ b/htdocs/install/modules/protector/trust_path/modules/protector/admin/index.php
@@ -183,7 +183,7 @@ echo "
     <td class='even'>
       <textarea name='group1_ips' id='group1_ips' style='width:200px;height:60px;'>$group1_ips4disp</textarea>
       <br />
-      " . htmlspecialchars(str_replace(ICMS_TRUST_PATH, 'TRUSTPATH', $protector->get_filepath4badips())) . "
+      " . htmlspecialchars(str_replace(ICMS_TRUST_PATH, 'TRUSTPATH', $protector->get_filepath4group1ips())) . "
     </td>
   </tr>
   <tr valign='top' align='" . _GLOBAL_LEFT . "'>

--- a/htdocs/libraries/icms/core/Logger.php
+++ b/htdocs/libraries/icms/core/Logger.php
@@ -269,8 +269,8 @@ class icms_core_Logger {
 	 */
 	function sanitizePath( $path) {
 		$path = str_replace(
-			array('\\', ICMS_ROOT_PATH, str_replace( '\\', '/', realpath(ICMS_ROOT_PATH))),
-			array('/', '', ''),
+			array('\\', ICMS_ROOT_PATH, ICMS_TRUST_PATH, str_replace( '\\', '/', realpath(ICMS_ROOT_PATH))),
+			array('/', '', 'TRUSTPATH', ''),
 			$path
 		);
 		return $path;


### PR DESCRIPTION
Allowed admin IPs was labeled incorrectly
Path disclosure for trust path in debug