### PR TITLE
Remove composer ignores from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,6 @@ updates:
       - "composer"
       - "dependencies"
     versioning-strategy: lockfile-only
-    ignore:
-      - dependency-name: composer/composer
-        versions:
-          - "> 1.10.13"
-          - "< 2"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
I think this will fix issues with composer updates when security issues were found.