### PR TITLE
Use imponeer/env for env function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
     "http-interop/http-factory-guzzle": "^1.0",
     "imponeer/criteria": "^1.0",
     "imponeer/editor-contracts": "^1.0",
+    "imponeer/env": "^1.0",
     "imponeer/smarty-db-resource": "^2.0",
     "imponeer/smarty-foreachq": "^1.0",
     "imponeer/smarty-image": "^1.0",
@@ -94,7 +95,6 @@
     "php-console/php-console": "^3.1",
     "phpmailer/phpmailer": "^6.0.7",
     "phpseclib/bcmath_compat": "^2.0",
-    "silinternational/php-env": "^2.1",
     "simplepie/simplepie": "^1.5",
     "smarty/smarty": "^4.0",
     "smottt/wideimage": "^v1.1.3",
@@ -322,7 +322,6 @@
       "php": "7.3.0"
     },
     "allow-plugins": {
-      "0.0.0/composer-include-files": true,
       "typo3/class-alias-loader": true,
       "impresscms/composer-addon-installer-plugin": true
     }

--- a/composer.lock
+++ b/composer.lock
@@ -1,20 +1,20 @@
 {
-    "_readme": [
-        "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
-        "This file is @generated automatically"
-    ],
-    "content-hash": "380f1a1fd3f517deaf6e29be788b0007",
-    "packages": [
-        {
-            "name": "0.0.0/composer-include-files",
-            "version": "1.6.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/hopeseekr-contribs/composer-include-files.git",
-                "reference": "6e6d0a52e05b31061367a9fe58b6d9b104d79ca4"
-            },
-            "dist": {
+  "_readme": [
+	"This file locks the dependencies of your project to a known state",
+	"Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+	"This file is @generated automatically"
+  ],
+  "content-hash": "78af278cb2fd6289b233f33f36b95d1d",
+  "packages": [
+	{
+	  "name": "0.0.0/composer-include-files",
+	  "version": "1.6.0",
+	  "source": {
+		"type": "git",
+		"url": "https://github.com/hopeseekr-contribs/composer-include-files.git",
+		"reference": "6e6d0a52e05b31061367a9fe58b6d9b104d79ca4"
+	  },
+	  "dist": {
                 "type": "zip",
                 "url": "https://api.github.com/repos/hopeseekr-contribs/composer-include-files/zipball/6e6d0a52e05b31061367a9fe58b6d9b104d79ca4",
                 "reference": "6e6d0a52e05b31061367a9fe58b6d9b104d79ca4",
@@ -1852,26 +1852,71 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
-            ],
-            "description": "Interfaces for building PHP classes that lets to easier make web editor integrations in your content management systems",
-            "support": {
-                "issues": "https://github.com/imponeer/editor-contracts/issues",
-                "source": "https://github.com/imponeer/editor-contracts/tree/v1.0.0"
-            },
-            "time": "2021-10-12T09:36:43+00:00"
-        },
-        {
-            "name": "imponeer/smarty-db-resource",
-            "version": "v2.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/imponeer/smarty-db-resource.git",
-                "reference": "8f7b482e598dd312004e443963e62d100ea28bb7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/imponeer/smarty-db-resource/zipball/8f7b482e598dd312004e443963e62d100ea28bb7",
+			  "MIT"
+			],
+		  "description": "Interfaces for building PHP classes that lets to easier make web editor integrations in your content management systems",
+		  "support": {
+			"issues": "https://github.com/imponeer/editor-contracts/issues",
+			"source": "https://github.com/imponeer/editor-contracts/tree/v1.0.0"
+		  },
+		  "time": "2021-10-12T09:36:43+00:00"
+		},
+	{
+	  "name": "imponeer/env",
+	  "version": "v1.0.0",
+	  "source": {
+		"type": "git",
+		"url": "https://github.com/imponeer/env.git",
+		"reference": "3efe70bdd2e9abfedbb4a1d0ae85902e791b0748"
+	  },
+	  "dist": {
+		"type": "zip",
+		"url": "https://api.github.com/repos/imponeer/env/zipball/3efe70bdd2e9abfedbb4a1d0ae85902e791b0748",
+		"reference": "3efe70bdd2e9abfedbb4a1d0ae85902e791b0748",
+		"shasum": ""
+	  },
+	  "require": {
+		"php": ">=7.2",
+		"silinternational/php-env": "^2.1"
+	  },
+	  "require-dev": {
+		"fakerphp/faker": "^1.19",
+		"phpunit/phpunit": ">=8"
+	  },
+	  "type": "library",
+	  "autoload": {
+		"files": [
+		  "src/functions.php"
+		]
+	  },
+	  "notification-url": "https://packagist.org/downloads/",
+	  "license": [
+		"MIT"
+	  ],
+	  "authors": [
+		{
+		  "name": "Raimondas Rimkevičius (aka MekDrop)",
+		  "email": "mekdrop@impresscms.org"
+		}
+	  ],
+	  "description": "Small helper dealing with environment variables",
+	  "support": {
+		"issues": "https://github.com/imponeer/env/issues",
+		"source": "https://github.com/imponeer/env/tree/v1.0.0"
+	  },
+	  "time": "2022-06-11T09:01:18+00:00"
+	},
+	{
+	  "name": "imponeer/smarty-db-resource",
+	  "version": "v2.1.1",
+	  "source": {
+		"type": "git",
+		"url": "https://github.com/imponeer/smarty-db-resource.git",
+		"reference": "8f7b482e598dd312004e443963e62d100ea28bb7"
+	  },
+	  "dist": {
+		"type": "zip",
+		"url": "https://api.github.com/repos/imponeer/smarty-db-resource/zipball/8f7b482e598dd312004e443963e62d100ea28bb7",
                 "reference": "8f7b482e598dd312004e443963e62d100ea28bb7",
                 "shasum": ""
             },
@@ -9906,5 +9951,5 @@
     "platform-overrides": {
         "php": "7.3.0"
     },
-    "plugin-api-version": "2.3.0"
+  "plugin-api-version": "2.2.0"
 }

--- a/include/functions.php
+++ b/include/functions.php
@@ -38,14 +38,6 @@
 use ImpressCMS\Core\DataFilter;
 use ImpressCMS\Core\Response\RedirectResponse;
 use ImpressCMS\Core\Response\ViewResponse;
-use Sil\PhpEnv\Env;
-
-if (!function_exists('env')) {
-	function env(string $key, $defaultValue = null)
-	{
-		return Env::get($key, $defaultValue);
-	}
-}
 
 if (!function_exists('xoops_header')) {
 	/**


### PR DESCRIPTION
Improves #1201

`env` function now comes from separate library `imponeer/env` to make it possible to share needed code between this and our composer plugin.