### PR TITLE
Fixes 'Deprecation Notice: rtrim(): Passing null to parameter #1 ($string) of type string is deprecated'

### DIFF
--- a/include/constants.php
+++ b/include/constants.php
@@ -10,7 +10,7 @@ if (!function_exists('env')) {
 }
 
 define('ICMS_ROOT_PATH', dirname(__DIR__));
-define('ICMS_URL', rtrim(env('URL'), '/'));
+define('ICMS_URL', rtrim((string)env('URL', 'http://localhost'), '/'));
 
 /**#@+
  * Creating ICMS specific constants


### PR DESCRIPTION
(as title says)