### PR TITLE
CLI console now uses English as default language

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -16,6 +16,11 @@ $xoopsOption = [
 ];
 require dirname(__DIR__) . '/mainfile.php';
 icms::getInstance()->boot(false);
+
+global $icmsConfig;
+if (!isset($icmsConfig['language'])) {
+	$icmsConfig['language'] = 'english';
+}
 icms_loadLanguageFile('core', 'global');
 icms_loadCommonLanguageFile();
 


### PR DESCRIPTION
That is needed to remove some unnecessary tries to load non-existing language files. 