### PR TITLE
Including necessary language file to prevent installation errors in PHP8

### DIFF
--- a/htdocs/install/makedata.php
+++ b/htdocs/install/makedata.php
@@ -104,7 +104,8 @@ function make_data(&$dbm, &$cm, $adminname, $adminlogin_name, $adminpass, $admin
 	}
 	include_once '../modules/system/language/'.$language.'/modinfo.php';
 	include_once '../modules/system/language/'.$language.'/common.php';
-
+	include_once '../language/' . $language . '/global.php';
+	
 	$modversion = array();
 	include_once '../modules/system/xoops_version.php';
 	$time = time();


### PR DESCRIPTION
PHP8 throws an error for undefined constants. modules/system/icms_version.php uses constants from language/<language>/global.php too