### PR TITLE
Move analytics code to preload

### DIFF
--- a/htdocs/header.php
+++ b/htdocs/header.php
@@ -60,20 +60,7 @@ $xoopsThemeFactory->defaultTheme = $icmsConfig['theme_set'];
  */
 $icmsTheme = $xoTheme = &$xoopsThemeFactory->createInstance(array('contentTemplate' => @$xoopsOption['template_main']));
 $xoopsTpl = $icmsTpl = &$xoTheme->template;
-// no longer needed because of ticket #751
-// if ($icmsConfigMetaFooter['use_google_analytics'] === TRUE
-// && isset($icmsConfigMetaFooter['google_analytics']) && $icmsConfigMetaFooter['google_analytics'] != '') {
-// /* Legacy GA urchin code */
-// //$xoTheme->addScript('http://www.google-analytics.com/urchin.js',array('type' => 'text/javascript'),'_uacct = "UA-' . $icmsConfigMetaFooter['google_analytics'] . '";urchinTracker();');
-// $scheme = parse_url(ICMS_URL, PHP_URL_SCHEME);
-// if ($scheme == 'http') {
-// /* New GA code, http protocol */
-// $xoTheme->addScript('http://www.google-analytics.com/ga.js', array('type' => 'text/javascript'),'');
-// } elseif ($scheme == 'https') {
-// /* New GA code, https protocol */
-// $xoTheme->addScript('https://ssl.google-analytics.com/ga.js', array('type' => 'text/javascript'),'');
-// }
-// }
+
 if (isset($icmsConfigMetaFooter['google_meta']) && $icmsConfigMetaFooter['google_meta'] != '') {
 	$xoTheme->addMeta('meta', 'verify-v1', $icmsConfigMetaFooter['google_meta']);
 	$xoTheme->addMeta('meta', 'google-site-verification', $icmsConfigMetaFooter['google_meta']);

--- a/htdocs/libraries/icms/view/theme/Object.php
+++ b/htdocs/libraries/icms/view/theme/Object.php
@@ -210,19 +210,6 @@ class icms_view_theme_Object {
 				$this->addMeta('meta', substr($name, 5), $value);
 			} elseif (substr($name, 0, 6) == 'footer') {
 				$values = $value;
-				if ($icmsConfigMetaFooter['use_google_analytics'] == TRUE && isset($icmsConfigMetaFooter['google_analytics']) && $icmsConfigMetaFooter['google_analytics'] != '') {
-
-					$values = $value . "<script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-" . $icmsConfigMetaFooter['google_analytics'] . "', 'auto');
-  ga('send', 'pageview');
-
-</script>";
-				}
 				$this->template->assign("xoops_$name", $values);
 				$this->template->assign("icms_$name", $values);
 			} else {

--- a/htdocs/plugins/preloads/googleanalytics.php
+++ b/htdocs/plugins/preloads/googleanalytics.php
@@ -2,63 +2,41 @@
 /**
  * googleanalytics ga4.php
  * Created by david on 13/02/2022 22:41
- *
+ * Modified by skenow on 11 June 2023
  */
 
 /**
  * preload class to include the Google Analytics V4 tag in the Head of the webpage, after replacing the smarty variable with the GA4 property code
  * This can certainly be improved by checking whether we can, based on the preferences by our users (GDPR and cookies)
  */
-class IcmsPreloadGoogleanalytics extends icms_preload_Item {
+class IcmsPreloadGa4 extends IcmsPreloadItem {
 
-    function eventBeforeFooter()
-    {
-        global $xoopsTpl;
-        global $icmsTheme;
-        global $icmsConfigMetaFooter;
+	function eventBeforeFooter() {
+		global $xoopsTpl;
+		global $icmsTheme;
+		global $icmsConfigMetaFooter;
+		global $xoTheme;
 
+		try {
 
-        try {
-            if ($icmsConfigMetaFooter['use_google_analytics'])
-			{
-				if(isset($icmsConfigMetaFooter['google_analytics']) && $icmsConfigMetaFooter['google_analytics'] != '') 
-				{
-					if(substr( $icmsConfigMetaFooter['use_google_analytics'], 0, 2 ) === "G-")
-					{
-						$this->insertGA4Tag($icmsConfigMetaFooter['google_analytics']);
-					}
-					else
-					{
-						$this->insertUniversalAnalyticsTag($icmsConfigMetaFooter['google_analytics']);
-					}
+			if ($icmsConfigMetaFooter['use_google_analytics'] == TRUE && isset($icmsConfigMetaFooter['google_analytics']) && $icmsConfigMetaFooter['google_analytics'] != '') {
+				if (substr($icmsConfigMetaFooter['google_analytics'], 0, 2 ) === "G-") {
+					$tagvalue = $icmsConfigMetaFooter['google_analytics'];
+				} else {
+					$tagvalue = 'UA-' . $icmsConfigMetaFooter['google_analytics'];
 				}
-            }
-        }
-        catch (Exception $e) {
-            echo $e->getMessage();
-        }
-    }
-
-	function insertUniversalAnalyticsTag(string $UAtag)
-	{
-		$icmsTheme->addScript('', '', '(function(i,s,o,g,r,a,m){i[\'GoogleAnalyticsObject\']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,\'script\',\'//www.google-analytics.com/analytics.js\',\'ga\');
-
-  ga(\'create\', \'UA-' . $UAtag  . '\', \'auto\');
-  ga(\'send\', \'pageview\');', 'module', '2001');
-
-	}
-
-	function insertGA4Tag(string $GA4tag)
-	{
-		$icmsTheme->addScript('https://www.googletagmanager.com/gtag/js?id=' . $GA4tag, ['async' => 'async'], '', 'module', 2000);
-		$icmsTheme->addScript('', '', 'window.dataLayer = window.dataLayer || [];
+				$xoTheme->addScript('https://www.googletagmanager.com/gtag/js?id=' . $tagvalue, ['async'=>'async'], '', 'module', 2000);
+				$xoTheme->addScript('', '', 'window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag(\'js\', new Date());
 
-    gtag(\'config\', \'' . $GA4tag . '\');', 'module', '2001');
-
+    gtag(\'config\', \'' . $tagvalue . '\');', 'module', '2001');
+			} else {
+				echo 'error getting icmsConfigMetaFooter';
+			}
+		}
+		catch (Exception $e) {
+			echo $e->getMessage();
+		}
 	}
 }

--- a/htdocs/plugins/preloads/googleanalytics.php
+++ b/htdocs/plugins/preloads/googleanalytics.php
@@ -19,19 +19,19 @@ class IcmsPreloadGoogleanalytics extends icms_preload_Item {
 
 
         try {
-
-            if ($icmsConfigMetaFooter['use_google_analytics'] && isset($icmsConfigMetaFooter['google_analytics']) && $icmsConfigMetaFooter['google_analytics'] != '') {
-				if(substr( $icmsConfigMetaFooter['use_google_analytics'], 0, 2 ) === "G-")
+            if ($icmsConfigMetaFooter['use_google_analytics'])
+			{
+				if(isset($icmsConfigMetaFooter['google_analytics']) && $icmsConfigMetaFooter['google_analytics'] != '') 
 				{
-					$this->insertGA4Tag($icmsConfigMetaFooter['use_google_analytics']);
+					if(substr( $icmsConfigMetaFooter['use_google_analytics'], 0, 2 ) === "G-")
+					{
+						$this->insertGA4Tag($icmsConfigMetaFooter['google_analytics']);
+					}
+					else
+					{
+						$this->insertUniversalAnalyticsTag($icmsConfigMetaFooter['google_analytics']);
+					}
 				}
-				else
-				{
-					$this->insertUniversalAnalyticsTag($icmsConfigMetaFooter['use_google_analytics']);
-				}
-            }
-            else {
-                echo 'error getting icmsConfigMetaFooter';
             }
         }
         catch (Exception $e) {

--- a/htdocs/plugins/preloads/googleanalytics.php
+++ b/htdocs/plugins/preloads/googleanalytics.php
@@ -53,7 +53,7 @@ class IcmsPreloadGoogleanalytics extends icms_preload_Item {
 
 	function insertGA4Tag(string $GA4tag)
 	{
-		$icmsTheme->addScript('https://www.googletagmanager.com/gtag/js?id=' . $GA4tag, ['async'], '', 'module', 2000);
+		$icmsTheme->addScript('https://www.googletagmanager.com/gtag/js?id=' . $GA4tag, ['async' => 'async'], '', 'module', 2000);
 		$icmsTheme->addScript('', '', 'window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag(\'js\', new Date());

--- a/htdocs/plugins/preloads/googleanalytics.php
+++ b/htdocs/plugins/preloads/googleanalytics.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * googleanalytics ga4.php
+ * Created by david on 13/02/2022 22:41
+ *
+ */
+
+/**
+ * preload class to include the Google Analytics V4 tag in the Head of the webpage, after replacing the smarty variable with the GA4 property code
+ * This can certainly be improved by checking whether we can, based on the preferences by our users (GDPR and cookies)
+ */
+class IcmsPreloadGoogleanalytics extends icms_preload_Item {
+
+    function eventBeforeFooter()
+    {
+        global $xoopsTpl;
+        global $icmsTheme;
+        global $icmsConfigMetaFooter;
+
+
+        try {
+
+            if ($icmsConfigMetaFooter['use_google_analytics'] && isset($icmsConfigMetaFooter['google_analytics']) && $icmsConfigMetaFooter['google_analytics'] != '') {
+				if(substr( $icmsConfigMetaFooter['use_google_analytics'], 0, 2 ) === "G-")
+				{
+					$this->insertGA4Tag($icmsConfigMetaFooter['use_google_analytics']);
+				}
+				else
+				{
+					$this->insertUniversalAnalyticsTag($icmsConfigMetaFooter['use_google_analytics']);
+				}
+            }
+            else {
+                echo 'error getting icmsConfigMetaFooter';
+            }
+        }
+        catch (Exception $e) {
+            echo $e->getMessage();
+        }
+    }
+
+	function insertUniversalAnalyticsTag(string $UAtag)
+	{
+		$icmsTheme->addScript('', '', '(function(i,s,o,g,r,a,m){i[\'GoogleAnalyticsObject\']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,\'script\',\'//www.google-analytics.com/analytics.js\',\'ga\');
+
+  ga(\'create\', \'UA-' . $UAtag  . '\', \'auto\');
+  ga(\'send\', \'pageview\');', 'module', '2001');
+
+	}
+
+	function insertGA4Tag(string $GA4tag)
+	{
+		$icmsTheme->addScript('https://www.googletagmanager.com/gtag/js?id=' . $GA4tag, ['async'], '', 'module', 2000);
+		$icmsTheme->addScript('', '', 'window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag(\'js\', new Date());
+
+    gtag(\'config\', \'' . $GA4tag . '\');', 'module', '2001');
+
+	}
+}


### PR DESCRIPTION
Move the UA code to the preload. This code also looks for the value of the Google Analytics tag and decides based on that whether to add the old UA or the new GA4 script