### PR TITLE
Adapt install texts for PHP requirements

### DIFF
--- a/htdocs/install/language/english/install.php
+++ b/htdocs/install/language/english/install.php
@@ -62,12 +62,12 @@ define( "INITIAL_SETTINGS_TITLE", "Please enter your initial settings" );
 define( "DATA_INSERTION", "Data insertion" );
 define( "DATA_INSERTION_TITLE", "Saving your settings to the database" );
 define( "WELCOME", "Welcome" );
-define( "NO_PHP5", "No PHP 5" );
+define( "NO_PHP5", "No PHP 7" );
 define( "WELCOME_TITLE", "Installation of ImpressCMS completed" );		// L0
 define( "MODULES_INSTALL", "Install modules" );
 define( "MODULES_INSTALL_TITLE", "Installation of modules " );
 define( "NO_PHP5_TITLE", "No PHP 7" );
-define( "NO_PHP5_CONTENT","PHP 7.4.0 minimum is required (PHP 8.1 is recommended) for ImpressCMS to function properly - your installation cannot continue. Please work with your hosting provider to upgrade your environment to a version of PHP that is newer than 7.4.0 (8..0 + is recommended) before attempting to install again.");
+define( "NO_PHP5_CONTENT","PHP 7.4.0 minimum is required (PHP 8.1 is recommended) for ImpressCMS to function properly - your installation cannot continue. Please work with your hosting provider to upgrade your environment to a version of PHP that is newer than 7.4.0 (8.1 is recommended) before attempting to install again.");
 define( "SAFE_MODE", "Safe Mode On" );
 define( "SAFE_MODE_TITLE", "Safe Mode On" );
 define( "SAFE_MODE_CONTENT", "ImpressCMS has detected PHP is running in Safe Mode. Because of this, your installation cannot continue. Please work with your hosting provider to change your environment before attempting to install again." );

--- a/htdocs/install/language/english/welcome.php
+++ b/htdocs/install/language/english/welcome.php
@@ -14,7 +14,7 @@ $content .= '
 <h3>Requirements</h3>
 <ul>
 	<li>- WWW Server: <a href="https://www.apache.org/" rel="external">Apache</a>, NGinx, IIS, Roxen, etc</li>
-	<li>- Script: <a href="https://www.php.net/" rel="external">PHP</a> 7.0+ and 16mb minimum memory allocation - PHP 8 is supported!</li>
+	<li>- Script: <a href="https://www.php.net/" rel="external">PHP</a> 7.4+ and 16mb minimum memory allocation - PHP 8.1 is recommended!</li>
 	<li>- Database: <a href="https://www.mysql.com/" rel="external">MySQL</a> 4.1.0 or higher, <a href="https://mariadb.org/" rel="external">MariaDB</a> 5.1 or higher</li>
 </ul>
 <h3>Before you install</h3>

--- a/htdocs/install/language/francais/welcome.php
+++ b/htdocs/install/language/francais/welcome.php
@@ -13,7 +13,7 @@ $content .= '
 <h3>Il faut au minimum</h3>
 <ul>
 	<li>WWW Server (<a href="http://www.apache.org/" rel="external">Apache</a>, IIS, Roxen, etc)</li>
-	<li><a href="http://www.php.net/" rel="external">PHP</a> 7.0+ avec 16Mo de mémoire minimum. PHP 8.0 est supporté!</li>
+	<li><a href="http://www.php.net/" rel="external">PHP</a> 7.4+ avec 16Mo de mémoire minimum. PHP 8.1 est recommandé!</li>
 	<li><a href="http://www.mysql.com/" rel="external">MySQL</a> 4.1.0 ou MariaDB 5.1 ou plus recent</li>
 </ul>
 <h3>Avant d\'installer</h3>

--- a/htdocs/install/language/italiano/welcome.php
+++ b/htdocs/install/language/italiano/welcome.php
@@ -14,7 +14,7 @@ $content .= '
 <h3>Requisiti di sistema</h3>
 <ul>
 	<li>WWW Server (<a href="http://www.apache.org/" target="_blank">Apache</a>, IIS, Roxen, ecc.)</li>
-	<li><a href="http://www.php.net/" target="_blank">PHP</a> 7.0 o maggiore (8.0 è supportato!) e 16MB minimo di allocazione di memoria </li>
+	<li><a href="http://www.php.net/" target="_blank">PHP</a> 7.4 o maggiore (8.1 è consigliato!) e 16MB minimo di allocazione di memoria </li>
 	<li><a href="http://www.mysql.com/" target="_blank">MySQL</a> 4.1.0 o maggiore oppure MariaDB 5.1 o maggiore</li>
 </ul>
 <h3>Prima di installare</h3>

--- a/htdocs/install/language/nederlands/welcome.php
+++ b/htdocs/install/language/nederlands/welcome.php
@@ -6,7 +6,7 @@ $content .= '
 	community websites, intranets, bedrijfssites, blogs en veel meer.
 </p>
 <p>
-	ImpressCMS wordt ter beschikking gesteld onder de 
+	ImpressCMS wordt ter beschikking gesteld onder de
 	<a href="https://www.gnu.org/licenses/old-licenses/gpl-2.0.html#top" rel="external">GNU General Public License (GPL) v2</a>
 	en is vrij om te gebruiken en aan te passen.
 	Het is vrij om te herverdelen zolang de termen van de GPLv2 worden gevolgd.
@@ -14,7 +14,7 @@ $content .= '
 <h3>Vereisten</h3>
 <ul>
 	<li>- Web Server: <a href="http://www.apache.org/" rel="external">Apache</a>, NGinx, IIS, Roxen, etc</li>
-	<li>- Script: <a href="http://www.php.net/" rel="external">PHP</a> 7.0+ en minstens 16MB beschikbaar geheugen.</li>
+	<li>- Script: <a href="http://www.php.net/" rel="external">PHP</a> 7.4+ en minstens 16MB beschikbaar geheugen. PHP 8.1 is sterk aanbevolen.</li>
 	<li>- Database: <a href="http://www.mysql.com/" rel="external">MySQL</a> 4.1.0 of nieuwer, <a href="https://mariadb.org/" rel="external">MariaDB</a> 5.1 of nieuwer</li>
 </ul>
 <h3>Voorbereiding voor de installatie</h3>


### PR DESCRIPTION
Some references were made in the welcome text to PHP 7.0, this now mentions a minimal requirement of PHP 7.4, and a recommendation for PHP 8.1