### PR TITLE
improve theme selector

### DIFF
--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -572,26 +572,22 @@ function b_system_info_edit($options) {
  * Shows the activated themes
  *
  * @param array $options The block options
- * @return array $block The themes block array
+ * @return array $block The themes block array with the elements, not the HTML anymore
  */
-function b_system_themes_show($options) {
+function b_system_themes_show($options){
 	global $icmsConfig;
-	$theme_options = '';
-	foreach ($icmsConfig['theme_set_allowed'] as $theme) {
-		$theme_options .= '<option value="' . $theme . '"';
-		if ($theme == $icmsConfig['theme_set']) {
-			$theme_options .= ' selected="selected"';
-		}
-		$theme_options .= '>' . $theme . '</option>';
-	}
-	$block = array();
-	if ($options[0] == 1) {
-		$block['theme_select'] = "<img vspace=\"2\" id=\"xoops_theme_img\" src=\"" . ICMS_THEME_URL . "/" . $icmsConfig['theme_set'] . "/shot.gif\" alt=\"screenshot\" width=\"" . (int) $options[1] . "\" /><br /><select id=\"theme_select\" name=\"theme_select\" onchange=\"showImgSelected('xoops_theme_img', 'theme_select', 'themes', '/shot.gif', '" . ICMS_URL . "');\">" . $theme_options . "</select><input type=\"submit\" value=\"" . _GO . "\" />";
-	} else {
-		$block['theme_select'] = '<select name="theme_select" onchange="submit();" size="3">' . $theme_options . '</select>';
-	}
 
-	$block['theme_select'] .= '<p>(' . sprintf(_MB_SYSTEM_NUMTHEME, count($icmsConfig['theme_set_allowed']) . '') . ')</p>';
+	$block = array();
+	foreach ($icmsConfig['theme_set_allowed'] as $theme) {
+		$imagefile = ICMS_THEME_URL . "/" . $theme . "/shot.gif";
+
+		$block['theme_select'][$theme]['name'] = $theme;
+		$block['theme_select'][$theme]['folder'] = $theme;
+		$block['theme_select'][$theme]['current'] = $theme == $icmsConfig['theme_set'];
+		$block['theme_select'][$theme]['option'] = $options[0];
+		if($options[0]==1)
+			$block['theme_select'][$theme]['image'] = $imagefile;
+	}
 	return $block;
 }
 

--- a/htdocs/modules/system/blocks/system_blocks.php
+++ b/htdocs/modules/system/blocks/system_blocks.php
@@ -572,22 +572,26 @@ function b_system_info_edit($options) {
  * Shows the activated themes
  *
  * @param array $options The block options
- * @return array $block The themes block array with the elements, not the HTML anymore
+ * @return array $block The themes block array
  */
-function b_system_themes_show($options){
+function b_system_themes_show($options) {
 	global $icmsConfig;
-
-	$block = array();
+	$theme_options = '';
 	foreach ($icmsConfig['theme_set_allowed'] as $theme) {
-		$imagefile = ICMS_THEME_URL . "/" . $theme . "/shot.gif";
-
-		$block['theme_select'][$theme]['name'] = $theme;
-		$block['theme_select'][$theme]['folder'] = $theme;
-		$block['theme_select'][$theme]['current'] = $theme == $icmsConfig['theme_set'];
-		$block['theme_select'][$theme]['option'] = $options[0];
-		if($options[0]==1)
-			$block['theme_select'][$theme]['image'] = $imagefile;
+		$theme_options .= '<option value="' . $theme . '"';
+		if ($theme == $icmsConfig['theme_set']) {
+			$theme_options .= ' selected="selected"';
+		}
+		$theme_options .= '>' . $theme . '</option>';
 	}
+	$block = array();
+	if ($options[0] == 1) {
+		$block['theme_select'] = "<img vspace=\"2\" id=\"xoops_theme_img\" src=\"" . ICMS_THEME_URL . "/" . $icmsConfig['theme_set'] . "/shot.gif\" alt=\"screenshot\" width=\"" . (int) $options[1] . "\" /><br /><select id=\"theme_select\" name=\"theme_select\" onchange=\"showImgSelected('xoops_theme_img', 'theme_select', 'themes', '/shot.gif', '" . ICMS_URL . "');\">" . $theme_options . "</select><input type=\"submit\" value=\"" . _GO . "\" />";
+	} else {
+		$block['theme_select'] = '<select name="theme_select" onchange="submit();" size="3">' . $theme_options . '</select>';
+	}
+
+	$block['theme_select'] .= '<p>(' . sprintf(_MB_SYSTEM_NUMTHEME, count($icmsConfig['theme_set_allowed']) . '') . ')</p>';
 	return $block;
 }
 

--- a/htdocs/modules/system/templates/blocks/system_block_themes.html
+++ b/htdocs/modules/system/templates/blocks/system_block_themes.html
@@ -3,7 +3,7 @@
 <div>
 	<select name="theme_select" onchange="submit();" size="3">
 	<{foreach item=theme from=$block.theme_select}>
-	<option value="<{$theme.folder}>"> <{$theme.name}></option>
+	<option value="<{$theme.folder}>"> <{if $theme.option>0}><img src="<{$theme.image}>"><br/><{/if}><{$theme.name}></option>
 	<{/foreach}>
 	</select>
 </div>

--- a/htdocs/modules/system/templates/blocks/system_block_themes.html
+++ b/htdocs/modules/system/templates/blocks/system_block_themes.html
@@ -1,7 +1,11 @@
 <div style="text-align: center;">
 <form action="index.php" method="post">
 <div>
-<{$block.theme_select}>
+	<select name="theme_select" onchange="submit();" size="3">
+	<{foreach item=theme from=$block.theme_select}>
+	<option value="<{$theme.folder}>"> <{$theme.name}></option>
+	<{/foreach}>
+	</select>
 </div>
 </form>
 </div>


### PR DESCRIPTION
The theme selector was previously generating the HTML within the block routine, leaving very few options for themes to work with. This change updates that : the block routine in system_blocks.php now generates an array with the relevant information, and the system_block_themes.html template uses that info to create the view.