### PR TITLE
Making sure password reset key is unique and temporary

### DIFF
--- a/htdocs/lostpass.php
+++ b/htdocs/lostpass.php
@@ -59,11 +59,11 @@ $code = '';
 if (!empty($_GET)) {
 	// in places where strict mode is not used for checkVarArray, make sure filter_ vars are not overwritten
 	if (isset($_GET['filter_post'])) unset ($_GET['filter_post']);
-    $clean_GET = icms_core_DataFilter::checkVarArray($_GET, $filter_get, FALSE);
+    $clean_GET = icms_core_DataFilter::checkVarArray($_GET, $filter_get, false);
     extract($clean_GET);
 }
 if (!empty($_POST)) {
-    $clean_POST = icms_core_DataFilter::checkVarArray($_POST, $filter_post, FALSE);
+	$clean_POST = icms_core_DataFilter::checkVarArray($_POST, $filter_post, false);
     extract($clean_POST);
 }
 if ($email == '') {
@@ -82,7 +82,7 @@ if (empty($getuser)) {
 } else {
 	$icmspass = new icms_core_Password();
 
-	$areyou = substr($getuser[0]->getVar('pass'), 0, 5);
+	$areyou = substr($getuser[0]->getVar('pass'), -5) . $getuser[0]->getVar('last_login');
 	if ($code != '' && $areyou == $code) {
 		$newpass = $icmspass->createSalt(8);
 		$pass = $icmspass->encryptPass($newpass);
@@ -97,7 +97,7 @@ if (empty($getuser)) {
 		$xoopsMailer->setToUsers($getuser[0]);
 		$xoopsMailer->setFromEmail($icmsConfig['adminmail']);
 		$xoopsMailer->setFromName($icmsConfig['sitename']);
-		$xoopsMailer->setSubject(sprintf(_US_NEWPWDREQ, ICMS_URL));
+		$xoopsMailer->setSubject(sprintf(_US_NEWPWDREQ, $icmsConfig['sitename'] . ' (' . ICMS_URL . ')'));
 		if (!$xoopsMailer->send()) {
 			echo $xoopsMailer->getErrors();
 		}
@@ -113,7 +113,7 @@ if (empty($getuser)) {
 			include 'footer.php';
 			exit();
 		}
-		redirect_header('user.php', 3, sprintf(_US_PWDMAILED, $getuser[0]->getVar('uname')), FALSE);
+		redirect_header('user.php', 3, sprintf(_US_PWDMAILED, $getuser[0]->getVar('uname')), false);
 		// If no Code, send it
 	} else {
 		$xoopsMailer = new icms_messaging_Handler();
@@ -127,7 +127,7 @@ if (empty($getuser)) {
 		$xoopsMailer->setToUsers($getuser[0]);
 		$xoopsMailer->setFromEmail($icmsConfig['adminmail']);
 		$xoopsMailer->setFromName($icmsConfig['sitename']);
-		$xoopsMailer->setSubject(sprintf(_US_NEWPWDREQ, $icmsConfig['sitename']));
+		$xoopsMailer->setSubject(sprintf(_US_NEWPWDREQ, $icmsConfig['sitename'] . ' (' . ICMS_URL . ')'));
 		/** Include header.php to start page rendering */
 		include 'header.php';
 		if (!$xoopsMailer->send()) {

--- a/htdocs/lostpass.php
+++ b/htdocs/lostpass.php
@@ -82,7 +82,7 @@ if (empty($getuser)) {
 } else {
 	$icmspass = new icms_core_Password();
 
-	$areyou = substr($getuser[0]->getVar('pass'), -5) . $getuser[0]->getVar('last_login');
+	$areyou = hash('sha1',substr($getuser[0]->getVar('pass'), -5) . $getuser[0]->getVar('last_login'));
 	if ($code != '' && $areyou == $code) {
 		$newpass = $icmspass->createSalt(8);
 		$pass = $icmspass->encryptPass($newpass);
@@ -114,8 +114,9 @@ if (empty($getuser)) {
 			exit();
 		}
 		redirect_header('user.php', 3, sprintf(_US_PWDMAILED, $getuser[0]->getVar('uname')), false);
-		// If no Code, send it
-	} else {
+
+	// If no Code, send it
+	} elseif ($code == '') {
 		$xoopsMailer = new icms_messaging_Handler();
 		$xoopsMailer->useMail();
 		$xoopsMailer->setTemplate('lostpass1.tpl');
@@ -138,5 +139,9 @@ if (empty($getuser)) {
 		echo '</h4>';
 		/** Include footer.php to complete page rendering */
 		include 'footer.php';
+		
+		// code is set and doesn't match - expired or attempt to guess/hack
+	} else {
+		redirect_header('user.php', 2, _US_SORRYNOTFOUND);
 	}
 }


### PR DESCRIPTION
Change in the structure of the data in the field over time has made the old partial string common for all users. This change makes it unique and temporary, basing a portion of the key on their last login. Cleaned up the email subjects a bit, too.