### PR TITLE
Remove banner tables and config item

### DIFF
--- a/htdocs/install/sql/mysql.data.sql
+++ b/htdocs/install/sql/mysql.data.sql
@@ -1,13 +1,3 @@
-#
-# Dumping data for table `bannerclient`
-#
-
-INSERT INTO bannerclient VALUES (0, 'ImpressCMS', 'ImpressCMS Dev Team', 'info@impresscms.org', '', '', '');
-
-#
-# Dumping data for table `bannerfinish`
-#
-
 # Adding dynamic block area/position system - TheRpLima - 2007-10-21
 #
 # Dumping data for table `block_positions`

--- a/htdocs/modules/system/admin/blocksadmin/class/blocksadmin.php
+++ b/htdocs/modules/system/admin/blocksadmin/class/blocksadmin.php
@@ -274,7 +274,7 @@ class SystemBlocksadminHandler extends icms_view_block_Handler {
 	public function getModulesArray($full = FALSE) {
 		if (!is_array($this->modules_name)) {
 			$icms_module_handler = icms::handler('icms_module');
-			$installed_modules = &$icms_module_handler->getObjects();
+			$installed_modules = $icms_module_handler->getObjects();
 			$this->modules_name[0]['name'] = _NONE;
 			$this->modules_name[0]['dirname'] = '';
 			foreach ($installed_modules as $module) {

--- a/htdocs/modules/system/include/update.php
+++ b/htdocs/modules/system/include/update.php
@@ -48,10 +48,10 @@ icms_loadLanguageFile('core', 'databaseupdater');
  * @param int $dbVersion The database version
  * @return mixed
  */
-function xoops_module_update_system(&$module, $oldversion = NULL, $dbVersion = NULL) {
+function xoops_module_update_system(&$module, $oldversion = null, $dbVersion = null) {
 	global $icmsConfig, $xoTheme;
 
-	$from_112 = $abortUpdate = FALSE;
+	$from_112 = $abortUpdate = false;
 
 	$oldversion = $module->getVar('version');
 	if ($oldversion < 120) {

--- a/htdocs/modules/system/include/update.php
+++ b/htdocs/modules/system/include/update.php
@@ -105,17 +105,13 @@ function xoops_module_update_system(&$module, $oldversion = NULL, $dbVersion = N
 
 	/* Begin upgrade to version 1.5 */
 	if (!$abortUpdate) {
-		$newDbVersion = 47;
+		$newDbVersion = 48;
 	}
 	try {
 		if ($dbVersion < $newDbVersion) {
 
 
 			// Remove all the legacy files that are were removed in 1.5.0
-			//$table = new icms_db_legacy_updater_Table('config');
-			//$icmsDatabaseUpdater->runQuery("ALTER TABLE `" . $table->name() . "` DROP INDEX conf_mod_cat_id, ADD INDEX mod_cat_order(conf_modid, conf_catid, conf_order)", 'Successfully altered the indexes on table config', '');
-			//unset($table);
-
 			// TODO: make a generic file removal function.
 			// Remove the 'deprecated' files in the root and all OpenID related files
 
@@ -172,6 +168,24 @@ function xoops_module_update_system(&$module, $oldversion = NULL, $dbVersion = N
 					echo 'Removed' . $foldertoremove . '</br>';
 				}
 			}
+
+			// remove old banners tables
+			$tablestodrop = array('banner', 'bannerclient', 'bannerfinish');
+			foreach ($tablestodrop as $table) {
+				$tableObj = new icms_db_legacy_updater_Table($table);
+				if ($tableObj->exists()) {
+					$tableObj->dropTable();
+				}
+			}
+			
+			// remove the banner config item
+			$criteria = new icms_db_criteria_Compo();
+			$criteria->add(new icms_db_criteria_Item('conf_name', 'banners'));
+			$config = $config_handler->getConfigs($criteria);
+			if (count($config) > 0) {
+				$config_handler->deleteConfig($config[0]);
+			}
+			
 			/* Finish up this portion of the db update */
 
 			if (!$abortUpdate) {

--- a/htdocs/modules/system/include/update.php
+++ b/htdocs/modules/system/include/update.php
@@ -177,36 +177,39 @@ function xoops_module_update_system(&$module, $oldversion = NULL, $dbVersion = N
 
 	/* Begin upgrade to version 2.0.0 beta 2 */
 	if (!$abortUpdate) $newDbVersion = 48;
-	try {
-		// remove old banners tables
-		$tablestodrop = array('banner', 'bannerclient', 'bannerfinish');
-		foreach ($tablestodrop as $table) {
-			$tableObj = new icms_db_legacy_updater_Table($table);
-			if ($tableObj->exists()) {
-				$tableObj->dropTable();
+		try {
+			/* things specific to this release */
+			if ($dbVersion < $newDbVersion) {
+				// remove old banners tables
+				$tablestodrop = array('banner', 'bannerclient', 'bannerfinish');
+				foreach ($tablestodrop as $table) {
+					$tableObj = new icms_db_legacy_updater_Table($table);
+					if ($tableObj->exists()) {
+						$tableObj->dropTable();
+					}
+				}
+			
+			// remove the banner config item
+			$criteria = new icms_db_criteria_Compo();
+			$criteria->add(new icms_db_criteria_Item('conf_name', 'banners'));
+			$config = $config_handler->getConfigs($criteria);
+			if (count($config) > 0) {
+				$config_handler->deleteConfig($config[0]);
 			}
-		}
-		
-		// remove the banner config item
-		$criteria = new icms_db_criteria_Compo();
-		$criteria->add(new icms_db_criteria_Item('conf_name', 'banners'));
-		$config = $config_handler->getConfigs($criteria);
-		if (count($config) > 0) {
-			$config_handler->deleteConfig($config[0]);
-		}
-		
-		// remove the openid config item
-		$criteria = new icms_db_criteria_Compo();
-		$criteria->add(new icms_db_criteria_Item('conf_name', 'auth_openid'));
-		$config = $config_handler->getConfigs($criteria);
-		if (count($config) > 0) {
-			$config_handler->deleteConfig($config[0]);
-		}
-		
-		/* Finish up this portion of the db update */
-		if (!$abortUpdate) {
-			$icmsDatabaseUpdater->updateModuleDBVersion($newDbVersion, 'system');
-			echo sprintf(_DATABASEUPDATER_UPDATE_OK, icms_conv_nr2local($newDbVersion)) . '<br />';
+			
+			// remove the openid config item
+			$criteria = new icms_db_criteria_Compo();
+			$criteria->add(new icms_db_criteria_Item('conf_name', 'auth_openid'));
+			$config = $config_handler->getConfigs($criteria);
+			if (count($config) > 0) {
+				$config_handler->deleteConfig($config[0]);
+			}
+			
+			/* Finish up this portion of the db update */
+			if (!$abortUpdate) {
+				$icmsDatabaseUpdater->updateModuleDBVersion($newDbVersion, 'system');
+				echo sprintf(_DATABASEUPDATER_UPDATE_OK, icms_conv_nr2local($newDbVersion)) . '<br />';
+			}
 		}
 	}
 	catch (Exception $e) {


### PR DESCRIPTION
This will remove the database tables for banners and the config item  left from previous versions of the core Resolves #1528 