### PR TITLE
Fix indirect variable handling in IPF form select (1.4.7)

### DIFF
--- a/htdocs/libraries/icms/ipf/form/elements/Select.php
+++ b/htdocs/libraries/icms/ipf/form/elements/Select.php
@@ -40,7 +40,7 @@ class icms_ipf_form_elements_Select extends icms_form_elements_Select {
 			// let's find if the method we need to call comes from an already defined object
 			if (isset($control['object'])) {
 				if (method_exists($control['object'], $control['method'])) {
-					if ($option_array = $control['object']->$control['method']()) {
+					if ($option_array = $control['object']->{$control['method']}()) {
 						// Adding the options array to the select element
 						$this->addOptionArray($option_array);
 					}


### PR DESCRIPTION
adding these brackets stops modules from bombing out saying that the function name should be a string. This is due to a [backward-incompatible change in PHP 7](https://www.php.net/manual/en/migration70.incompatible.php#migration70.incompatible.variable-handling.indirect) in handling indirect variables.

As we are no longer supporting PHP5, this can safely be added.