### PR TITLE
Templated form elements

### DIFF
--- a/htdocs/libraries/icms/form/Element.php
+++ b/htdocs/libraries/icms/form/Element.php
@@ -116,6 +116,13 @@ abstract class icms_form_Element {
 	 * @var	string
 	 */
 	private $_description = "";
+
+	/**
+	 * template for this field
+	 */
+	protected icms_view_Tpl $_tpl;
+	protected string $_customTemplate = "";
+
 	/**#@-*/
 
 	/**

--- a/htdocs/libraries/icms/form/Element.php
+++ b/htdocs/libraries/icms/form/Element.php
@@ -120,8 +120,8 @@ abstract class icms_form_Element {
 	/**
 	 * template for this field
 	 */
-	protected icms_view_Tpl $_tpl;
-	protected string $_customTemplate = "";
+	protected icms_view_Tpl $tpl;
+	protected string $customTemplate = "";
 
 	/**#@-*/
 

--- a/htdocs/libraries/icms/form/elements/Button.php
+++ b/htdocs/libraries/icms/form/elements/Button.php
@@ -116,6 +116,16 @@ class icms_form_elements_Button extends icms_form_Element {
 	 * @return	string
 	 */
 	public function render() {
-		return "<input type='".$this->getType()."' class='formButton' name='".$this->getName()."'  id='".$this->getName()."' value='".$this->getValue()."'".$this->getExtra()." />";
+	$this->_tpl = new icms_view_Tpl();
+	$this->_tpl->assign('type', $this->getType());
+	$this->_tpl->assign('name', $this->getName());
+	$this->_tpl->assign('id', $this->getName());
+	$this->_tpl->assign('value', $this->getValue());
+	$this->_tpl->assign('extra', $this->getExtra());
+
+		$element_html_template = $this->_customTemplate ? $this->_customTemplate : strtolower(static::class) . '_display.html';
+		return $this->_tpl->fetch('db:' . $element_html_template);
+
+//		return "<input type='".$this->getType()."' class='formButton' name='".$this->getName()."'  id='".$this->getName()."' value='".$this->getValue()."'".$this->getExtra()." />";
 	}
 }

--- a/htdocs/libraries/icms/form/elements/Button.php
+++ b/htdocs/libraries/icms/form/elements/Button.php
@@ -116,15 +116,15 @@ class icms_form_elements_Button extends icms_form_Element {
 	 * @return	string
 	 */
 	public function render() {
-	$this->_tpl = new icms_view_Tpl();
-	$this->_tpl->assign('type', $this->getType());
-	$this->_tpl->assign('name', $this->getName());
-	$this->_tpl->assign('id', $this->getName());
-	$this->_tpl->assign('value', $this->getValue());
-	$this->_tpl->assign('extra', $this->getExtra());
+	$this->tpl = new icms_view_Tpl();
+	$this->tpl->assign('type', $this->getType());
+	$this->tpl->assign('name', $this->getName());
+	$this->tpl->assign('id', $this->getName());
+	$this->tpl->assign('value', $this->getValue());
+	$this->tpl->assign('extra', $this->getExtra());
 
 	$element_html_template = $this->_customTemplate ? $this->_customTemplate : strtolower(static::class) . '_display.html';
 	
-	return $this->_tpl->fetch('db:' . $element_html_template);
+	return $this->tpl->fetch('db:' . $element_html_template);
 	}
 }

--- a/htdocs/libraries/icms/form/elements/Button.php
+++ b/htdocs/libraries/icms/form/elements/Button.php
@@ -123,9 +123,8 @@ class icms_form_elements_Button extends icms_form_Element {
 	$this->_tpl->assign('value', $this->getValue());
 	$this->_tpl->assign('extra', $this->getExtra());
 
-		$element_html_template = $this->_customTemplate ? $this->_customTemplate : strtolower(static::class) . '_display.html';
-		return $this->_tpl->fetch('db:' . $element_html_template);
-
-//		return "<input type='".$this->getType()."' class='formButton' name='".$this->getName()."'  id='".$this->getName()."' value='".$this->getValue()."'".$this->getExtra()." />";
+	$element_html_template = $this->_customTemplate ? $this->_customTemplate : strtolower(static::class) . '_display.html';
+	
+	return $this->_tpl->fetch('db:' . $element_html_template);
 	}
 }

--- a/htdocs/libraries/icms/form/elements/Checkbox.php
+++ b/htdocs/libraries/icms/form/elements/Checkbox.php
@@ -186,9 +186,10 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 	 * @return    string
 	 */
 	public function render() {
-		$ret = "<div class='grouped'>";
+
 		$ele_name = $this->getName();
 		$ele_value = $this->getValue();
+
 		$ele_options = $this->getOptions();
 		$ele_extra = $this->getExtra();
 		$ele_delimeter = $this->getDelimeter();
@@ -196,20 +197,34 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 			$ele_name = $ele_name . "[]";
 			$this->setName($ele_name);
 		}
-		foreach ($ele_options as $value => $name) {
-			$ret .= "<span class='icms_checkboxoption'><input type='checkbox' name='" . $ele_name
-				. "' id='" . $ele_name . "_item_" . $value . "' value='" . htmlspecialchars($value, ENT_QUOTES) . "'";
-			if (count($ele_value) > 0 && in_array($value, $ele_value)) {
-				$ret .= " checked='checked'";
-			}
-			$ret .= $ele_extra . " /><label for='" . $ele_name . "_item_" . $value . "'>" . $name . "</label></span>" . $ele_delimeter;
-		}
-		if (count($ele_options) > 1) {
-			$ret .= "<div class='icms_checkboxoption'><input type='checkbox' id='"
-				. $ele_name	. "_checkemall' class='checkemall' /><label for='"
-				. $ele_name . "_checkemall'>" . _CHECKALL . "</label></div>";
-		}
-		$ret .= "</div>";
-		return $ret;
+//		foreach ($ele_options as $value => $name) {
+//			$ret .= "<span class='icms_checkboxoption'><input type='checkbox' name='" . $ele_name
+//				. "' id='" . $ele_name . "_item_" . $value . "' value='" . htmlspecialchars($value, ENT_QUOTES) . "'";
+//			if (count($ele_value) > 0 && in_array($value, $ele_value)) {
+//				$ret .= " checked='checked'";
+//			}
+//			$ret .= $ele_extra . " />
+//			<label for='" . $ele_name . "_item_" . $value . "'>" . $name . "</label>
+//			</span>" . $ele_delimeter;
+//		}
+//		if (count($ele_options) > 1) {
+//			$ret .= "<div class='icms_checkboxoption'><input type='checkbox' id='"
+//				. $ele_name	. "_checkemall' class='checkemall' /><label for='"
+//				. $ele_name . "_checkemall'>" . _CHECKALL . "</label></div>";
+//		}
+//		$ret .= "</div>";
+
+		$this->_tpl = new icms_view_Tpl();
+		$this->_tpl->assign('ele_name', $ele_name);
+		$this->_tpl->assign('ele_id', $ele_name);
+		$this->_tpl->assign('ele_value', $ele_value);
+		$this->_tpl->assign('ele_options', $ele_options);
+		$this->_tpl->assign('ele_extra', $ele_extra);
+		$this->_tpl->assign('ele_delimeter', $ele_delimeter);
+
+		$element_html_template = $this->_customTemplate ? $this->_customTemplate : strtolower(static::class) . '_display.html';
+		return $this->_tpl->fetch('db:' . $element_html_template);
+
 	}
+
 }

--- a/htdocs/libraries/icms/form/elements/Checkbox.php
+++ b/htdocs/libraries/icms/form/elements/Checkbox.php
@@ -197,22 +197,6 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 			$ele_name = $ele_name . "[]";
 			$this->setName($ele_name);
 		}
-//		foreach ($ele_options as $value => $name) {
-//			$ret .= "<span class='icms_checkboxoption'><input type='checkbox' name='" . $ele_name
-//				. "' id='" . $ele_name . "_item_" . $value . "' value='" . htmlspecialchars($value, ENT_QUOTES) . "'";
-//			if (count($ele_value) > 0 && in_array($value, $ele_value)) {
-//				$ret .= " checked='checked'";
-//			}
-//			$ret .= $ele_extra . " />
-//			<label for='" . $ele_name . "_item_" . $value . "'>" . $name . "</label>
-//			</span>" . $ele_delimeter;
-//		}
-//		if (count($ele_options) > 1) {
-//			$ret .= "<div class='icms_checkboxoption'><input type='checkbox' id='"
-//				. $ele_name	. "_checkemall' class='checkemall' /><label for='"
-//				. $ele_name . "_checkemall'>" . _CHECKALL . "</label></div>";
-//		}
-//		$ret .= "</div>";
 
 		$this->_tpl = new icms_view_Tpl();
 		$this->_tpl->assign('ele_name', $ele_name);
@@ -224,7 +208,5 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 
 		$element_html_template = $this->_customTemplate ? $this->_customTemplate : strtolower(static::class) . '_display.html';
 		return $this->_tpl->fetch('db:' . $element_html_template);
-
 	}
-
 }

--- a/htdocs/libraries/icms/form/elements/Checkbox.php
+++ b/htdocs/libraries/icms/form/elements/Checkbox.php
@@ -198,15 +198,15 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 			$this->setName($ele_name);
 		}
 
-		$this->_tpl = new icms_view_Tpl();
-		$this->_tpl->assign('ele_name', $ele_name);
-		$this->_tpl->assign('ele_id', $ele_name);
-		$this->_tpl->assign('ele_value', $ele_value);
-		$this->_tpl->assign('ele_options', $ele_options);
-		$this->_tpl->assign('ele_extra', $ele_extra);
-		$this->_tpl->assign('ele_delimeter', $ele_delimeter);
+		$this->tpl = new icms_view_Tpl();
+		$this->tpl->assign('ele_name', $ele_name);
+		$this->tpl->assign('ele_id', $ele_name);
+		$this->tpl->assign('ele_value', $ele_value);
+		$this->tpl->assign('ele_options', $ele_options);
+		$this->tpl->assign('ele_extra', $ele_extra);
+		$this->tpl->assign('ele_delimeter', $ele_delimeter);
 
 		$element_html_template = $this->_customTemplate ? $this->_customTemplate : strtolower(static::class) . '_display.html';
-		return $this->_tpl->fetch('db:' . $element_html_template);
+		return $this->tpl->fetch('db:' . $element_html_template);
 	}
 }

--- a/htdocs/libraries/icms/form/elements/Password.php
+++ b/htdocs/libraries/icms/form/elements/Password.php
@@ -163,15 +163,6 @@ class icms_form_elements_Password extends icms_form_Element {
 	 * @return	string	HTML
 	 */
 	public function render() {
-		//global $icmsConfigUser;
-		$ele_name = $this->getName();
-		return "<input class='" . $this->getClassName()
-			. "' type='password' name='" . $ele_name
-			. "' id='" . $ele_name
-			. "' size='" . $this->getSize()
-			. "' maxlength='" . $this->getMaxlength()
-			. "' value='" . $this->getValue() . "'" . $this->getExtra() . " " . ($this->autoComplete ? "" : "autocomplete='off' ")
-			. "/>";
 
 		$this->_tpl = new icms_view_Tpl();
 		$this->_tpl->assign('ele_name', $this->getName());

--- a/htdocs/libraries/icms/form/elements/Password.php
+++ b/htdocs/libraries/icms/form/elements/Password.php
@@ -163,7 +163,7 @@ class icms_form_elements_Password extends icms_form_Element {
 	 * @return	string	HTML
 	 */
 	public function render() {
-		global $icmsConfigUser;
+		//global $icmsConfigUser;
 		$ele_name = $this->getName();
 		return "<input class='" . $this->getClassName()
 			. "' type='password' name='" . $ele_name
@@ -172,5 +172,18 @@ class icms_form_elements_Password extends icms_form_Element {
 			. "' maxlength='" . $this->getMaxlength()
 			. "' value='" . $this->getValue() . "'" . $this->getExtra() . " " . ($this->autoComplete ? "" : "autocomplete='off' ")
 			. "/>";
+
+		$this->_tpl = new icms_view_Tpl();
+		$this->_tpl->assign('ele_name', $this->getName());
+		$this->_tpl->assign('ele_class', $this->getClassName());
+		$this->_tpl->assign('ele_id', $this->getName());
+		$this->_tpl->assign('ele_size', $this->getSize());
+		$this->_tpl->assign('ele_maxlength', $this->getMaxlength());
+		$this->_tpl->assign('ele_value', $this->getValue());
+		$this->_tpl->assign('ele_extra', $this->getExtra());
+		$this->_tpl->assign('ele_autocomplete', $this->autoComplete);
+
+		$element_html_template = $this->_customTemplate ? $this->_customTemplate : strtolower(static::class) . '_display.html';
+		return $this->_tpl->fetch('db:' . $element_html_template);
 	}
 }

--- a/htdocs/libraries/icms/form/elements/Password.php
+++ b/htdocs/libraries/icms/form/elements/Password.php
@@ -164,15 +164,15 @@ class icms_form_elements_Password extends icms_form_Element {
 	 */
 	public function render() {
 
-		$this->_tpl = new icms_view_Tpl();
-		$this->_tpl->assign('ele_name', $this->getName());
-		$this->_tpl->assign('ele_class', $this->getClassName());
-		$this->_tpl->assign('ele_id', $this->getName());
-		$this->_tpl->assign('ele_size', $this->getSize());
-		$this->_tpl->assign('ele_maxlength', $this->getMaxlength());
-		$this->_tpl->assign('ele_value', $this->getValue());
-		$this->_tpl->assign('ele_extra', $this->getExtra());
-		$this->_tpl->assign('ele_autocomplete', $this->autoComplete);
+		$this->tpl = new icms_view_Tpl();
+		$this->tpl->assign('ele_name', $this->getName());
+		$this->tpl->assign('ele_class', $this->getClassName());
+		$this->tpl->assign('ele_id', $this->getName());
+		$this->tpl->assign('ele_size', $this->getSize());
+		$this->tpl->assign('ele_maxlength', $this->getMaxlength());
+		$this->tpl->assign('ele_value', $this->getValue());
+		$this->tpl->assign('ele_extra', $this->getExtra());
+		$this->tpl->assign('ele_autocomplete', $this->autoComplete);
 
 		$element_html_template = $this->_customTemplate ? $this->_customTemplate : strtolower(static::class) . '_display.html';
 		return $this->_tpl->fetch('db:' . $element_html_template);

--- a/htdocs/libraries/icms/form/elements/Text.php
+++ b/htdocs/libraries/icms/form/elements/Text.php
@@ -141,6 +141,18 @@ class icms_form_elements_Text extends icms_form_Element {
 			. "' maxlength='" . $this->getMaxlength()
 			. "' value='" . $this->getValue() . "'" . $this->getExtra()
 			. " />";
+
+		$this->_tpl = new icms_view_Tpl();
+//		$this->_tpl->assign('type', $this->getType());
+		$this->_tpl->assign('ele_name', $this->getName());
+		$this->_tpl->assign('ele_id', $this->getName());
+		$this->_tpl->assign('ele_size', $this->getSize());
+		$this->_tpl->assign('ele_maxlength', $this->getMaxlength());
+		$this->_tpl->assign('ele_value', $this->getValue());
+		$this->_tpl->assign('ele_extra', $this->getExtra());
+
+		$element_html_template = $this->_customTemplate ? $this->_customTemplate : strtolower(static::class) . '_display.html';
+		return $this->_tpl->fetch('db:' . $element_html_template);
 	}
 }
 

--- a/htdocs/libraries/icms/form/elements/Text.php
+++ b/htdocs/libraries/icms/form/elements/Text.php
@@ -135,15 +135,14 @@ class icms_form_elements_Text extends icms_form_Element {
 	 * @return	string  HTML
 	 */
 	public function render() {
-		return "<input type='text' name='" . $this->getName()
-			. "' id='" . $this->getName()
-			. "' size='" . $this->getSize()
-			. "' maxlength='" . $this->getMaxlength()
-			. "' value='" . $this->getValue() . "'" . $this->getExtra()
-			. " />";
+//		return "<input type='text' name='" . $this->getName()
+//			. "' id='" . $this->getName()
+//			. "' size='" . $this->getSize()
+//			. "' maxlength='" . $this->getMaxlength()
+//			. "' value='" . $this->getValue() . "'" . $this->getExtra()
+//			. " />";
 
 		$this->_tpl = new icms_view_Tpl();
-//		$this->_tpl->assign('type', $this->getType());
 		$this->_tpl->assign('ele_name', $this->getName());
 		$this->_tpl->assign('ele_id', $this->getName());
 		$this->_tpl->assign('ele_size', $this->getSize());

--- a/htdocs/libraries/icms/form/elements/Text.php
+++ b/htdocs/libraries/icms/form/elements/Text.php
@@ -135,13 +135,6 @@ class icms_form_elements_Text extends icms_form_Element {
 	 * @return	string  HTML
 	 */
 	public function render() {
-//		return "<input type='text' name='" . $this->getName()
-//			. "' id='" . $this->getName()
-//			. "' size='" . $this->getSize()
-//			. "' maxlength='" . $this->getMaxlength()
-//			. "' value='" . $this->getValue() . "'" . $this->getExtra()
-//			. " />";
-
 		$this->_tpl = new icms_view_Tpl();
 		$this->_tpl->assign('ele_name', $this->getName());
 		$this->_tpl->assign('ele_id', $this->getName());

--- a/htdocs/libraries/icms/form/elements/Text.php
+++ b/htdocs/libraries/icms/form/elements/Text.php
@@ -135,13 +135,13 @@ class icms_form_elements_Text extends icms_form_Element {
 	 * @return	string  HTML
 	 */
 	public function render() {
-		$this->_tpl = new icms_view_Tpl();
-		$this->_tpl->assign('ele_name', $this->getName());
-		$this->_tpl->assign('ele_id', $this->getName());
-		$this->_tpl->assign('ele_size', $this->getSize());
-		$this->_tpl->assign('ele_maxlength', $this->getMaxlength());
-		$this->_tpl->assign('ele_value', $this->getValue());
-		$this->_tpl->assign('ele_extra', $this->getExtra());
+		$this->tpl = new icms_view_Tpl();
+		$this->tpl->assign('ele_name', $this->getName());
+		$this->tpl->assign('ele_id', $this->getName());
+		$this->tpl->assign('ele_size', $this->getSize());
+		$this->tpl->assign('ele_maxlength', $this->getMaxlength());
+		$this->tpl->assign('ele_value', $this->getValue());
+		$this->tpl->assign('ele_extra', $this->getExtra());
 
 		$element_html_template = $this->_customTemplate ? $this->_customTemplate : strtolower(static::class) . '_display.html';
 		return $this->_tpl->fetch('db:' . $element_html_template);

--- a/htdocs/modules/system/icms_version.php
+++ b/htdocs/modules/system/icms_version.php
@@ -218,4 +218,7 @@ $modversion['templates'] = array(
 	array('file' => 'system_popup_imagemanager_editimg.html', 'description' => ''),
 	array('file' => 'system_popup_imagemanager_img.html', 'description' => ''),
 	array('file' => 'system_popup_imagemanager_imglist.html', 'description' => ''),
-	array('file' => 'system_popup_imagemanager.html', 'description' => ''));
+	array('file' => 'system_popup_imagemanager.html', 'description' => ''),
+	array('file' => 'icms_form_elements_button_display.html', 'description' => 'Display template for a button'),
+	array('file' => 'icms_form_elements_checkbox_display.html', 'description' => 'Display template for a checkbox')
+);

--- a/htdocs/modules/system/icms_version.php
+++ b/htdocs/modules/system/icms_version.php
@@ -220,5 +220,6 @@ $modversion['templates'] = array(
 	array('file' => 'system_popup_imagemanager_imglist.html', 'description' => ''),
 	array('file' => 'system_popup_imagemanager.html', 'description' => ''),
 	array('file' => 'icms_form_elements_button_display.html', 'description' => 'Display template for a button'),
-	array('file' => 'icms_form_elements_checkbox_display.html', 'description' => 'Display template for a checkbox')
+	array('file' => 'icms_form_elements_checkbox_display.html', 'description' => 'Display template for a checkbox'),
+	array('file' => 'icms_form_elements_text_display.html', 'description' => 'Display template for a text')
 );

--- a/htdocs/modules/system/icms_version.php
+++ b/htdocs/modules/system/icms_version.php
@@ -221,5 +221,6 @@ $modversion['templates'] = array(
 	array('file' => 'system_popup_imagemanager.html', 'description' => ''),
 	array('file' => 'icms_form_elements_button_display.html', 'description' => 'Display template for a button'),
 	array('file' => 'icms_form_elements_checkbox_display.html', 'description' => 'Display template for a checkbox'),
-	array('file' => 'icms_form_elements_text_display.html', 'description' => 'Display template for a text')
+	array('file' => 'icms_form_elements_text_display.html', 'description' => 'Display template for a text'),
+	array('file' => 'icms_form_elements_password_display.html', 'description' => 'Display template for a password field')
 );

--- a/htdocs/modules/system/templates/icms_form_elements_button_display.html
+++ b/htdocs/modules/system/templates/icms_form_elements_button_display.html
@@ -1,0 +1,1 @@
+<input type='<{$type}>' class='formButton' name='<{$name}>'  id='<{$name}>' value='<{$value}>' <{$extra}> />

--- a/htdocs/modules/system/templates/icms_form_elements_checkbox_display.html
+++ b/htdocs/modules/system/templates/icms_form_elements_checkbox_display.html
@@ -1,0 +1,15 @@
+<div class="grouped">
+	<{foreach from=$ele_options item=option name=checkbox}>
+	<span class="icms_checkboxoption">
+		<input type="checkbox" name="<{$ele_name}>" id="<{$ele_id}>_item_<{$smarty.foreach.checkbox.iteration}>" value="<{$smarty.foreach.checkbox.iteration}>">
+		<label for="<{$ele_id}>_item_<{$smarty.foreach.checkbox.iteration}>"><{$option}></label>
+	</span>
+	&nbsp;
+	<{/foreach}>
+	<{if $smarty.foreach.checkbox.total gt 1 }>
+	<div class='icms_checkboxoption'>
+		<input type='checkbox' id='<{$ele_name}>_checkemall' class='checkemall' />
+		<label for='<{$ele_name}>_checkemall'><{$smarty.const._CHECKALL}></label>
+	</div>
+	<{/if}>
+</div>

--- a/htdocs/modules/system/templates/icms_form_elements_password_display.html
+++ b/htdocs/modules/system/templates/icms_form_elements_password_display.html
@@ -1,0 +1,3 @@
+<!--<input type='text' name='" . $this->getName() . "' id='" . $this->getName()	. "' size='" . $this->getSize()	. "' maxlength='" . $this->getMaxlength() . "' value='" . $this->getValue() . "'" . $this->getExtra()-->
+<!--. " />";-->
+<input type="text" name="<{$ele_name}>"  id="<{$ele_name}>" size="<{$ele_size}>" maxlength="<{$ele_maxlength}>" value="<{$ele_value}>" <{$ele_extra}> <{if $ele_autocomplete != ""}><{$ele_autocomplete}><{/if}> />

--- a/htdocs/modules/system/templates/icms_form_elements_password_display.html
+++ b/htdocs/modules/system/templates/icms_form_elements_password_display.html
@@ -1,3 +1,1 @@
-<!--<input type='text' name='" . $this->getName() . "' id='" . $this->getName()	. "' size='" . $this->getSize()	. "' maxlength='" . $this->getMaxlength() . "' value='" . $this->getValue() . "'" . $this->getExtra()-->
-<!--. " />";-->
-<input type="text" name="<{$ele_name}>"  id="<{$ele_name}>" size="<{$ele_size}>" maxlength="<{$ele_maxlength}>" value="<{$ele_value}>" <{$ele_extra}> <{if $ele_autocomplete != ""}><{$ele_autocomplete}><{/if}> />
+<input type="password" name="<{$ele_name}>"  id="<{$ele_name}>" size="<{$ele_size}>" maxlength="<{$ele_maxlength}>" value="<{$ele_value}>" <{$ele_extra}> <{if $ele_autocomplete != ""}><{$ele_autocomplete}><{/if}> />

--- a/htdocs/modules/system/templates/icms_form_elements_text_display.html
+++ b/htdocs/modules/system/templates/icms_form_elements_text_display.html
@@ -1,0 +1,3 @@
+<!--<input type='text' name='" . $this->getName() . "' id='" . $this->getName()	. "' size='" . $this->getSize()	. "' maxlength='" . $this->getMaxlength() . "' value='" . $this->getValue() . "'" . $this->getExtra()-->
+<!--. " />";-->
+<input type="text" name="<{$ele_name}>"  id="<{$ele_name}>" size="<{$ele_size}>" maxlength="<{$ele_maxlength}>" value="<{$ele_value}>" <{$ele_extra}> />

--- a/htdocs/modules/system/templates/icms_form_elements_text_display.html
+++ b/htdocs/modules/system/templates/icms_form_elements_text_display.html
@@ -1,3 +1,1 @@
-<!--<input type='text' name='" . $this->getName() . "' id='" . $this->getName()	. "' size='" . $this->getSize()	. "' maxlength='" . $this->getMaxlength() . "' value='" . $this->getValue() . "'" . $this->getExtra()-->
-<!--. " />";-->
-<input type="text" name="<{$ele_name}>"  id="<{$ele_name}>" size="<{$ele_size}>" maxlength="<{$ele_maxlength}>" value="<{$ele_value}>" <{$ele_extra}> />
+<input type="text" name="<{$ele_name}>" id="<{$ele_name}>" size="<{$ele_size}>" maxlength="<{$ele_maxlength}>" value="<{$ele_value}>" <{$ele_extra}> />


### PR DESCRIPTION
CSS frameworks (Bulma, Bootstrap, Tailwind, ...) and almost every theme out there need specific HTML markup for their form solution to work well. The HTML implementation in the core was not flexible enough to allow that. I started with a button, and will gradually transform all hardcoded HTML in the core to using templates. 

I've started with these 4:
* Text Area
* Password
* Button
* Checkbox

Other parts will come in other PRs 

Smarty is included in the core specifically for this kind of functionality, so let's not re-invent the wheel. 

Added benefit : by using Smarty we should also have template caching, for that extra micro-second of speed :-)

