### PR TITLE
handle if columns to remove from users table have already been removed

### DIFF
--- a/htdocs/modules/system/include/update.php
+++ b/htdocs/modules/system/include/update.php
@@ -209,6 +209,17 @@ function xoops_module_update_system(&$module, $oldversion = null, $dbVersion = n
 			if (count($config) > 0) {
 				icms::$config->deleteConfig($config[0]);
 			}
+			
+			// remove columns from the users table
+			$tabletoupdate = 'users';
+			$columnstoremove = array('openid', 'user_viewoid');
+			$table = new icms_db_legacy_updater_Table($tabletoupdate);
+			foreach ($columnstoremove as $column) {
+				if ($table->fieldExists($column)) {
+					$table->addDropedField($column);
+				}
+			}
+			$table->dropFields();
 
 			/* Finish up this portion of the db update */
 			if (!$abortUpdate) {

--- a/htdocs/modules/system/include/update.php
+++ b/htdocs/modules/system/include/update.php
@@ -186,7 +186,7 @@ function xoops_module_update_system(&$module, $oldversion = null, $dbVersion = n
 			/* things specific to this release */
 			if ($dbVersion < $newDbVersion) {
 				// remove old banners tables
-				$tablestodrop = array('banner', 'bannerclient', 'bannerfinish');
+				$tablestodrop = ['banner', 'bannerclient', 'bannerfinish'];
 				foreach ($tablestodrop as $table) {
 					$tableObj = new icms_db_legacy_updater_Table($table);
 					if ($tableObj->exists()) {
@@ -194,22 +194,17 @@ function xoops_module_update_system(&$module, $oldversion = null, $dbVersion = n
 					}
 				}
 
-			// remove the banner config item
-			$criteria = new icms_db_criteria_Compo();
-			$criteria->add(new icms_db_criteria_Item('conf_name', 'banners'));
-			$config = icms::$config->getConfigs($criteria);
-			if (count($config) > 0) {
-				icms::$config->deleteConfig($config[0]);
+			// remove unused config itmes
+			$itemstoremove = ['banners', 'auth_openid'];
+			foreach ($itemstoremove as $item) {
+				$criteria = new icms_db_criteria_Compo();
+				$criteria->add(new icms_db_criteria_Item('conf_name', $item));
+				$config = icms::$config->getConfigs($criteria);
+				if (count($config) > 0) {
+					icms::$config->deleteConfig($config[0]);
+				}
 			}
-
-			// remove the openid config item
-			$criteria = new icms_db_criteria_Compo();
-			$criteria->add(new icms_db_criteria_Item('conf_name', 'auth_openid'));
-			$config = icms::$config->getConfigs($criteria);
-			if (count($config) > 0) {
-				icms::$config->deleteConfig($config[0]);
-			}
-			
+				
 			// remove columns from the users table
 			$tabletoupdate = 'users';
 			$columnstoremove = ['openid', 'user_viewoid'];
@@ -219,7 +214,9 @@ function xoops_module_update_system(&$module, $oldversion = null, $dbVersion = n
 					$table->addDropedField($column);
 				}
 			}
-			$table->dropFields();
+			if ($table->getDropedFields()) {
+				$table->dropFields();
+			}
 
 			/* Finish up this portion of the db update */
 			if (!$abortUpdate) {

--- a/htdocs/modules/system/include/update.php
+++ b/htdocs/modules/system/include/update.php
@@ -212,7 +212,7 @@ function xoops_module_update_system(&$module, $oldversion = null, $dbVersion = n
 			
 			// remove columns from the users table
 			$tabletoupdate = 'users';
-			$columnstoremove = array('openid', 'user_viewoid');
+			$columnstoremove = ['openid', 'user_viewoid'];
 			$table = new icms_db_legacy_updater_Table($tabletoupdate);
 			foreach ($columnstoremove as $column) {
 				if ($table->fieldExists($column)) {


### PR DESCRIPTION
The method for dropping tables expects an array of columns. If there are none, there is a fatal error. Resolves #1589 

I had also done some minor changes to declaring some arrays and reused some code to reduce lines.