### PR TITLE
Ckeditor custom config

### DIFF
--- a/htdocs/editors/CKeditor/ckeditor/config.js
+++ b/htdocs/editors/CKeditor/ckeditor/config.js
@@ -75,5 +75,6 @@ CKEDITOR.editorConfig = function( config ) {
 			':lol:', ':-x', ':-p', ':oops:', ':cry:', ':evil:', ':roll:',
 			';-)', ':pint:', ':hammer:', ':idea:' ];
 	
+	config.allowedContent = true;
 	config.versionCheck = false;
 };

--- a/htdocs/editors/CKeditor/ckeditor/config.js
+++ b/htdocs/editors/CKeditor/ckeditor/config.js
@@ -7,34 +7,73 @@ CKEDITOR.editorConfig = function( config ) {
 	// Define changes to default configuration here.
 	// For complete reference see:
 	// https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html
+	
+	// Different toolbars, based on the user's group
+	
+	/*
+	 * Basic Config (ANONYMOUS TOOLBAR)
+	 */
+	config.toolbar_Basic = [ [ 'Format', '-', 'Bold', 'Italic', '-',
+			'NumberedList', 'BulletedList', '-', 'Link', 'Unlink' ] ];
 
-	// The toolbar groups arrangement, optimized for two toolbar rows.
-	config.toolbarGroups = [
-		{ name: 'clipboard',   groups: [ 'clipboard', 'undo' ] },
-		{ name: 'editing',     groups: [ 'find', 'selection', 'spellchecker' ] },
-		{ name: 'links' },
-		{ name: 'insert' },
-		{ name: 'forms' },
-		{ name: 'tools' },
-		{ name: 'document',	   groups: [ 'mode', 'document', 'doctools' ] },
-		{ name: 'others' },
-		'/',
-		{ name: 'basicstyles', groups: [ 'basicstyles', 'cleanup' ] },
-		{ name: 'paragraph',   groups: [ 'list', 'indent', 'blocks', 'align', 'bidi' ] },
-		{ name: 'styles' },
-		{ name: 'colors' },
-		{ name: 'about' }
-	];
+	/*
+	 * Medium Config (REGISTERED TOOLBAR)
+	 */
+	config.toolbar_Normal = [
+			[ 'Source' ],
+			[ 'Cut', 'Copy', 'Paste', 'PasteText', 'PasteFromWord', '-',
+					'SpellChecker', 'Scayt' ],
+			[ 'Undo', 'Redo', 'Find', 'Replace', '-', 'SelectAll',
+					'RemoveFormat' ],
+			[ 'Image', 'Table', 'HorizontalRule', 'Smiley', 'SpecialChar' ],
+			'/',
+			[ 'Bold', 'Italic', 'Underline', 'Strike', '-', 'Subscript',
+					'Superscript' ],
+			[ 'NumberedList', 'BulletedList', '-', 'Outdent', 'Indent',
+					'Blockquote' ],
+			[ 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock' ],
+			[ 'Link', 'Unlink', 'Anchor' ], '/',
+			[ 'Format', 'Font', 'FontSize' ], [ 'TextColor', 'BGColor' ], ];
 
-	// Remove some buttons provided by the standard plugins, which are
-	// not needed in the Standard(s) toolbar.
-	config.removeButtons = 'Underline,Subscript,Superscript';
+	/*
+	 * Full Config (ADMIN TOOLBAR)
+	 */
+	config.toolbar_Full = [
+			[ 'Source' ],
+			[ 'Cut', 'Copy', 'Paste', 'PasteText', 'PasteFromWord', '-',
+					'SpellChecker', 'Scayt' ],
+			[ 'Undo', 'Redo', 'Find', 'Replace', '-', 'SelectAll',
+					'RemoveFormat' ],
+			[ 'Image', 'oembed', 'Flash', 'Table', 'HorizontalRule', 'Smiley',
+					'SpecialChar' ],
+			'/',
+			[ 'Bold', 'Italic', 'Underline', 'Strike', '-', 'Subscript',
+					'Superscript' ],
+			[ 'NumberedList', 'BulletedList', '-', 'Outdent', 'Indent',
+					'Blockquote' ],
+			[ 'JustifyLeft', 'JustifyCenter', 'JustifyRight', 'JustifyBlock' ],
+			[ 'Link', 'Unlink', 'Anchor' ], '/',
+			[ 'Format', 'Font', 'FontSize' ], [ 'TextColor', 'BGColor' ],
+			[ 'Maximize', 'ShowBlocks' ], ];
 
 	// Set the most common block elements.
 	config.format_tags = 'p;h1;h2;h3;pre';
 
-	// Simplify the dialog windows.
-	config.removeDialogTabs = 'image:advanced;link:advanced';
+	config.smiley_path = CKEDITOR.basePath + '../../../uploads/';
 
+	config.smiley_images = [ 'smil3dbd4d4e4c4f2.gif', 'smil3dbd4d6422f04.gif',
+			'smil3dbd4d75edb5e.gif', 'smil3dbd4d8676346.gif',
+			'smil3dbd4d99c6eaa.gif', 'smil3dbd4daabd491.gif',
+			'smil3dbd4dbc14f3f.gif', 'smil3dbd4dcd7b9f4.gif',
+			'smil3dbd4ddd6835f.gif', 'smil3dbd4df1944ee.gif',
+			'smil3dbd4e02c5440.gif', 'smil3dbd4e1748cc9.gif',
+			'smil3dbd4e29bbcc7.gif', 'smil3dbd4e398ff7b.gif',
+			'smil3dbd4e4c2e742.gif', 'smil3dbd4e5e7563a.gif',
+			'smil3dbd4e7853679.gif' ];
+
+	config.smiley_descriptions = [ ':-D', ':-)', ':-(', ':-o', ':-?', '8-)',
+			':lol:', ':-x', ':-p', ':oops:', ':cry:', ':evil:', ':roll:',
+			';-)', ':pint:', ':hammer:', ':idea:' ];
+	
 	config.versionCheck = false;
 };

--- a/htdocs/editors/CKeditor/ckeditor/config.js
+++ b/htdocs/editors/CKeditor/ckeditor/config.js
@@ -7,9 +7,9 @@ CKEDITOR.editorConfig = function( config ) {
 	// Define changes to default configuration here.
 	// For complete reference see:
 	// https://ckeditor.com/docs/ckeditor4/latest/api/CKEDITOR_config.html
-	
+
 	// Different toolbars, based on the user's group
-	
+
 	/*
 	 * Basic Config (ANONYMOUS TOOLBAR)
 	 */
@@ -74,7 +74,7 @@ CKEDITOR.editorConfig = function( config ) {
 	config.smiley_descriptions = [ ':-D', ':-)', ':-(', ':-o', ':-?', '8-)',
 			':lol:', ':-x', ':-p', ':oops:', ':cry:', ':evil:', ':roll:',
 			';-)', ':pint:', ':hammer:', ':idea:' ];
-	
+
 	config.allowedContent = true;
 	config.versionCheck = false;
 };


### PR DESCRIPTION
This adds back the custom toolbars based on the user's groups. The plugins are from the original inclusion of FCKeditor and may need to be adjusted for what is in this release. The build-config.js had the plugins being used. 