### PR TITLE
Gracefully handle empty tables

### DIFF
--- a/htdocs/libraries/icms/ipf/view/Table.php
+++ b/htdocs/libraries/icms/ipf/view/Table.php
@@ -602,11 +602,15 @@ class icms_ipf_view_Table {
 		/* filter the user input - only allow specified variables */
 		if (!empty($_GET)) {
 			$clean_GET = icms_core_DataFilter::checkVarArray($_GET, $filter_get, true);
-			extract($clean_GET);
+			if (!empty($clean_GET)) {
+				extract($clean_GET);
+			}
 		}
 		if (!empty($_POST)) {
 			$clean_POST = icms_core_DataFilter::checkVarArray($_POST, $filter_post, true);
-			extract($clean_POST);
+			if (!empty($clean_POST)) {
+				extract($clean_POST);
+			}
 		}
 
 		$server_vars = icms_core_DataFilter::checkVarArray($_SERVER, $filter_server, true);


### PR DESCRIPTION
### **User description**
in PHP 8.3 (and perhaps lower as well) extract doesn't work with an empty array.


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent `extract()` from running on empty arrays

- Add checks for empty filtered GET and POST arrays

- Improve compatibility with PHP 8.3 and lower


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Table.php</strong><dd><code>Add guards before extract() for empty arrays in Table rendering</code></dd></summary>
<hr>

htdocs/libraries/icms/ipf/view/Table.php

<li>Added checks to ensure <code>extract()</code> is only called on non-empty arrays<br> <li> Prevents errors when filtered GET or POST arrays are empty<br> <li> Addresses compatibility issues with PHP 8.3 and possibly earlier <br>versions


</details>


  </td>
  <td><a href="https://github.com/ImpressCMS/impresscms/pull/1630/files#diff-173a65648086a4d9eaacfabf8c9f8d5f127c9afe8ee725f77f0e22af71a13ebe">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>