### PR TITLE
Testing for icms::$module before trying to check DB version

### DIFF
--- a/htdocs/modules/system/include/update.php
+++ b/htdocs/modules/system/include/update.php
@@ -44,7 +44,7 @@ icms_loadLanguageFile('core', 'databaseupdater');
 if (is_object(icms::$module)) {
 	define('SYSTEM_DB_VERSION', icms::$module->getDBVersion());
 } else {
-	define('SYSTEM_DB_VERSION', 0);
+	define('SYSTEM_DB_VERSION', 48);
 }
 
 /**


### PR DESCRIPTION
### **User description**
During the installation, at the module install stage, the system module update is invoked and icms::$module does not exist, throwing a fatal error. Adding a test for the existence of the object.


___

### **PR Type**
Bug fix


___

### **Description**
- Add null check for `icms::$module` before accessing methods

- Prevent fatal error during system module installation

- Fix issue where `SYSTEM_DB_VERSION` constant definition fails


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Installation Process"] --> B["System Module Update"]
  B --> C{"icms::$module exists?"}
  C -->|No| D["Skip DB Version Definition"]
  C -->|Yes| E["Define SYSTEM_DB_VERSION"]
  E --> F["Continue Installation"]
  D --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>update.php</strong><dd><code>Add null check for module object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

htdocs/modules/system/include/update.php

<ul><li>Add conditional check for <code>icms::$module</code> object existence<br> <li> Wrap <code>SYSTEM_DB_VERSION</code> constant definition in null check<br> <li> Prevent fatal error during module installation process</ul>


</details>


  </td>
  <td><a href="https://github.com/ImpressCMS/impresscms/pull/1642/files#diff-30964f05e1328ea85fdf63d99f17021799c3f5024446420b825eb6a99a008016">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

