### PR TITLE
fix:github version check now handles newer installed versions than latest on github

### DIFF
--- a/htdocs/libraries/icms/core/Versioncheckergithub.php
+++ b/htdocs/libraries/icms/core/Versioncheckergithub.php
@@ -91,7 +91,6 @@ class icms_core_Versioncheckergithub extends icms_core_Versionchecker implements
 
 		if (!empty($github_data) && is_array($github_data)) {
 		    $latest_release = $github_data;
-
 			// Populate the latest array with the new structure
 			$this->latest['version_name'] = $latest_release['name'];
 			$this->latest['build'] = $latest_release['id'];
@@ -118,10 +117,10 @@ class icms_core_Versioncheckergithub extends icms_core_Versionchecker implements
 
 
 
-	private function get_latest($owner = 'ImpressCMS', $repo = 'impresscms') : array
+	private function get_latest($owner = 'ImpressCMS', $repo = 'impresscms')
 	{
-		$url= $this->version_url;
-		//$url = "https://api.github.com/repos/$owner/$repo/releases";
+		//$url= $this->version_url;
+		$url = "https://api.github.com/repos/$owner/$repo/releases/latest";
 
 		// Call the GitHub API
 		$ch = curl_init();
@@ -134,6 +133,7 @@ class icms_core_Versioncheckergithub extends icms_core_Versionchecker implements
 
 	    $http_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 	    if ($response === FALSE || $http_code !== 200) {
+
 	        $error = curl_error($ch);
 	        curl_close($ch);
 	        $this->errors[] = "GitHub API error: " . ($error ?: "HTTP $http_code");
@@ -142,15 +142,15 @@ class icms_core_Versioncheckergithub extends icms_core_Versionchecker implements
 	    curl_close($ch);
 
 	    // Decode the JSON response
-	    $releases = json_decode($response, true);
-    
+	    $release = json_decode($response, true);
+
 	    if (json_last_error() !== JSON_ERROR_NONE) {
 	        $this->errors[] = "JSON decode error: " . json_last_error_msg();
 	        return array();
 	    }
 
-		// Return releases or empty array if decode failed
-		return is_array($releases) ? $releases : array();
+		// Return release or empty array if decode failed
+		return $release ? $release : array();
 	}
 	public function getLatestVersionNumber() : string {
 		$versionName = $this->getLatestVersionName();
@@ -239,12 +239,11 @@ class icms_core_Versioncheckergithub extends icms_core_Versionchecker implements
 	{
 		$latestVersion = $this->getLatestVersionNumber();
 		$installedVersion = $this->getInstalledVersionNumber();
-
 		if (empty($latestVersion) || empty($installedVersion)) {
 			return false;
 	    }
-    
-	    return version_compare($latestVersion, $installedVersion, '>');
+
+	    return version_compare($latestVersion, $installedVersion, ">");
 	}
 
 	public function hasLatest(): bool

--- a/htdocs/modules/system/admin/version/main.php
+++ b/htdocs/modules/system/admin/version/main.php
@@ -37,20 +37,17 @@ global $icmsAdminTpl;
 $icmsVersionChecker = icms_core_Versioncheckergithub::getInstance();
 icms_cp_header();
 
-if ($icmsVersionChecker->check()) {
-
+$icmsVersionChecker->check();
 	$icmsAdminTpl->assign('latest', $icmsVersionChecker->latest);
 	$icmsAdminTpl->assign('installed', $icmsVersionChecker->installed);
 	$icmsAdminTpl->assign('update_available', $icmsVersionChecker->hasUpdate());
 	$icmsAdminTpl->assign('latest_installed', $icmsVersionChecker->hasLatest());
 
-} else {
-
 	$checkerErrors = $icmsVersionChecker->getErrors(TRUE);
 	if ($checkerErrors) {
 		$icmsAdminTpl->assign('errors', $checkerErrors);
 	}
-}
+
 
 /* retrieve the PHP and OS information*/
 $sysinfo = array();

--- a/htdocs/modules/system/templates/system_adm_version.html
+++ b/htdocs/modules/system/templates/system_adm_version.html
@@ -2,7 +2,7 @@
 
 <div class="head" style="padding: 2px; margin-bottom: 5px;">
 	<strong><{$smarty.const._AM_VERSION_YOUR_VERSION}></strong> <{$installed.version_name}>
-	<strong>Latest Version</strong> <{$latest.version}>
+	<strong>Latest Version</strong> <{$latest.version_name}>
 </div>
 
 <{if $update_available == "1"}>


### PR DESCRIPTION
This shouldn't really happen, but it can... Some logic was flawed.