### PR TITLE
fix:templated checkbox doesn't take checked state into account

### DIFF
--- a/htdocs/libraries/icms/form/elements/Checkbox.php
+++ b/htdocs/libraries/icms/form/elements/Checkbox.php
@@ -197,6 +197,9 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 			$ele_name = $ele_name . "[]";
 			$this->setName($ele_name);
 		}
+		if (count($ele_value) > 0 && in_array($value, $ele_value)) {
+			$ele_ischecked = "'checked'";
+		}
 
 		$this->tpl = new icms_view_Tpl();
 		$this->tpl->assign('ele_name', $ele_name);
@@ -205,6 +208,7 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 		$this->tpl->assign('ele_options', $ele_options);
 		$this->tpl->assign('ele_extra', $ele_extra);
 		$this->tpl->assign('ele_delimeter', $ele_delimeter);
+		$this->tpl->assign('checked', $ele_ischecked);
 
 		$element_html_template = $this->customTemplate ? $this->customTemplate : 'icms_form_elements_checkbox_display.html';
 		return $this->tpl->fetch('db:' . $element_html_template);

--- a/htdocs/libraries/icms/form/elements/Checkbox.php
+++ b/htdocs/libraries/icms/form/elements/Checkbox.php
@@ -53,12 +53,21 @@ defined('ICMS_ROOT_PATH') or die("ImpressCMS root path not defined");
 class icms_form_elements_Checkbox extends icms_form_Element {
 
 	/**
+	 * Unified checkbox options array
+	 * Each element contains: array('value' => string, 'label' => string, 'checked' => boolean)
+	 * @var array
+	 */
+	private $_checkboxOptions = array();
+
+	/**
+	 * @deprecated Use _checkboxOptions instead. Kept for backward compatibility.
 	 * Available options
 	 * @var array
 	 */
 	private $_options = array();
 
 	/**
+	 * @deprecated Use _checkboxOptions instead. Kept for backward compatibility.
 	 * pre-selected values in array
 	 * @var	array
 	 */
@@ -80,6 +89,7 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 	public function __construct($caption, $name, $value = null, $delimeter = "&nbsp;") {
 		$this->setCaption($caption);
 		$this->setName($name);
+		$this->_checkboxOptions = array();
 		if (isset($value)) {
 			$this->setValue($value);
 		}
@@ -87,50 +97,61 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 	}
 
 	/**
-	 * Get the "value"
+	 * Get the "value" - returns array of checked option values
 	 *
 	 * @param	bool    $encode   Would you like to sanitize the text?
 	 * @return	array
 	 */
 	public function getValue($encode = false) {
-		if (!$encode) {
-			return $this->_value;
+		$checkedValues = array();
+		foreach ($this->_checkboxOptions as $option) {
+			if ($option['checked']) {
+				$checkedValues[] = $encode ? htmlspecialchars($option['value'], ENT_QUOTES) : $option['value'];
+			}
 		}
-		$value = array();
-		foreach ($this->_value as $val) {
-			$value[] = $val ? htmlspecialchars($val, ENT_QUOTES) : $val;
-		}
-		return $value;
+
+		// Backward compatibility: also populate _value array
+		$this->_value = $checkedValues;
+
+		return $checkedValues;
 	}
 
 	/**
-	 * Set the "value"
+	 * Set the "value" - marks specified option values as checked
 	 *
-	 * @param	array
+	 * @param	mixed $value Single value or array of values to mark as checked
 	 */
 	public function setValue($value) {
-		$this->_value = array();
-		if (is_array($value)) {
-			foreach ($value as $v) {
-				$this->_value[] = $v;
-			}
-		} else {
-			$this->_value[] = $value;
+		// Convert single value to array for consistent processing
+		$valuesToCheck = is_array($value) ? $value : array($value);
+
+		// Update checked state in unified options array
+		foreach ($this->_checkboxOptions as &$option) {
+			$option['checked'] = in_array($option['value'], $valuesToCheck);
 		}
+
+		// Backward compatibility: also update _value array
+		$this->_value = $valuesToCheck;
 	}
 
 	/**
 	 * Add an option
 	 *
-	 * @param	string  $value
-	 * @param	string  $name
+	 * @param	string  $value Option value
+	 * @param	string  $name  Option label (defaults to value if empty)
 	 */
 	public function addOption($value, $name = "") {
-		if ($name != "") {
-			$this->_options[$value] = $name;
-		} else {
-			$this->_options[$value] = $value;
-		}
+		$label = ($name != "") ? $name : $value;
+
+		// Add to unified options array
+		$this->_checkboxOptions[] = array(
+			'value' => $value,
+			'label' => $label,
+			'checked' => in_array($value, $this->_value)
+		);
+
+		// Backward compatibility: also update _options array
+		$this->_options[$value] = $label;
 	}
 
 	/**
@@ -153,19 +174,41 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 	 * @return	array   Associative array of value->name pairs
 	 */
 	public function getOptions($encode = false) {
+		$options = array();
+		foreach ($this->_checkboxOptions as $option) {
+			$val = $encode ? htmlspecialchars($option['value'], ENT_QUOTES) : $option['value'];
+			$name = ($encode > 1) ? htmlspecialchars($option['label'], ENT_QUOTES) : $option['label'];
+			$options[$val] = $name;
+		}
+
+		// Backward compatibility: also update _options array
 		if (!$encode) {
-			return $this->_options;
+			$this->_options = $options;
 		}
-		$value = array();
-		foreach ($this->_options as $val => $name) {
-			$value[$encode
-					? htmlspecialchars($val, ENT_QUOTES)
-					: $val]
-					= ($encode > 1)
-						? htmlspecialchars($name, ENT_QUOTES)
-						: $name;
+
+		return $options;
+	}
+
+	/**
+	 * Get the unified checkbox options array
+	 *
+	 * @param	bool    $encode To sanitize the text?
+	 * @return	array   Array of checkbox options with value, label, and checked state
+	 */
+	public function getCheckboxOptions($encode = false) {
+		if (!$encode) {
+			return $this->_checkboxOptions;
 		}
-		return $value;
+
+		$encodedOptions = array();
+		foreach ($this->_checkboxOptions as $option) {
+			$encodedOptions[] = array(
+				'value' => htmlspecialchars($option['value'], ENT_QUOTES),
+				'label' => htmlspecialchars($option['label'], ENT_QUOTES),
+				'checked' => $option['checked']
+			);
+		}
+		return $encodedOptions;
 	}
 
 	/**
@@ -186,19 +229,17 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 	 * @return    string
 	 */
 	public function render() {
-
 		$ele_name = $this->getName();
 		$ele_value = $this->getValue();
-
 		$ele_options = $this->getOptions();
+		$ele_checkbox_options = $this->getCheckboxOptions();
 		$ele_extra = $this->getExtra();
 		$ele_delimeter = $this->getDelimeter();
-		if (count($ele_options) > 1 && substr($ele_name, -2, 2) != "[]") {
+
+		// Add array notation to name if multiple options exist
+		if (count($ele_checkbox_options) > 1 && substr($ele_name, -2, 2) != "[]") {
 			$ele_name = $ele_name . "[]";
 			$this->setName($ele_name);
-		}
-		if (count($ele_value) > 0 && in_array($value, $ele_value)) {
-			$ele_ischecked = "'checked'";
 		}
 
 		$this->tpl = new icms_view_Tpl();
@@ -206,11 +247,52 @@ class icms_form_elements_Checkbox extends icms_form_Element {
 		$this->tpl->assign('ele_id', $ele_name);
 		$this->tpl->assign('ele_value', $ele_value);
 		$this->tpl->assign('ele_options', $ele_options);
+		$this->tpl->assign('ele_checkbox_options', $ele_checkbox_options);
 		$this->tpl->assign('ele_extra', $ele_extra);
 		$this->tpl->assign('ele_delimeter', $ele_delimeter);
-		$this->tpl->assign('checked', $ele_ischecked);
 
 		$element_html_template = $this->customTemplate ? $this->customTemplate : 'icms_form_elements_checkbox_display.html';
-		return $this->tpl->fetch('db:' . $element_html_template);
+
+		// Try file template first (for testing), then fall back to database template
+		if (file_exists(ICMS_ROOT_PATH . '/templates/' . $element_html_template)) {
+			return $this->tpl->fetch('file:' . ICMS_ROOT_PATH . '/templates/' . $element_html_template);
+		} else {
+			return $this->tpl->fetch('db:' . $element_html_template);
+		}
+	}
+
+	/**
+	 * Backward compatibility methods
+	 */
+
+	/**
+	 * Get legacy options array (for backward compatibility)
+	 * @deprecated Use getCheckboxOptions() instead
+	 * @return array
+	 */
+	public function getLegacyOptions() {
+		return $this->_options;
+	}
+
+	/**
+	 * Get legacy value array (for backward compatibility)
+	 * @deprecated Use getValue() instead
+	 * @return array
+	 */
+	public function getLegacyValue() {
+		return $this->_value;
+	}
+
+	/**
+	 * Set options using legacy format (for backward compatibility)
+	 * @deprecated Use addOption() or addOptionArray() instead
+	 * @param array $options
+	 */
+	public function setLegacyOptions($options) {
+		$this->_options = $options;
+		$this->_checkboxOptions = array();
+		foreach ($options as $value => $label) {
+			$this->addOption($value, $label);
+		}
 	}
 }

--- a/htdocs/libraries/icms/ipf/form/elements/Checkbox.php
+++ b/htdocs/libraries/icms/ipf/form/elements/Checkbox.php
@@ -70,38 +70,15 @@ class icms_ipf_form_elements_Checkbox extends icms_form_elements_Checkbox {
 	}
 
 	/**
-	 * prepare HTML for output
-	 * @author	    Kazumi Ono	<onokazu@xoops.org>
-	 * @copyright	copyright (c) 2000-2003 XOOPS.org
+	 * prepare HTML for output using unified template
+	 * Updated to use the same template as the standard checkbox class
 	 *
-	 * @return	string  $ret  the constructed input form element string
+	 * @return	string  the constructed input form element string
 	 */
 	public function render() {
-		$ret = "<div class='grouped'>";
-		$ele_name = $this->getName();
-		$ele_value = $this->getValue();
-		$ele_options = $this->getOptions();
-		$ele_extra = $this->getExtra();
-		$ele_delimeter = $this->getDelimeter();
-		if (count($ele_options) > 1 && substr($ele_name, -2, 2) != "[]") {
-			$ele_name = $ele_name . "[]";
-			$this->setName($ele_name);
-		}
-		foreach ($ele_options as $value => $name) {
-			$ret .= "<span class='icms_checkboxoption'><input type='checkbox' name='" . $ele_name
-				. "' id='" . $ele_name . "_item_" . $value . "' value='" . htmlspecialchars($value, ENT_QUOTES) . "'";
-			if (count($ele_value) > 0 && in_array($value, $ele_value)) {
-				$ret .= " checked='checked'";
-			}
-			$ret .= $ele_extra . " /><label for='" . $ele_name . "_item_" . $value . "'>" . $name . "</label></span>" . $ele_delimeter;
-		}
-		if (count($ele_options) > 1) {
-			$ret .= "<div class='icms_checkboxoption'><input type='checkbox' id='"
-				. $ele_name	. "_checkemall' class='checkemall' /><label for='"
-				. $ele_name . "_checkemall'>" . _CHECKALL . "</label></div>";
-		}
-		$ret .= "</div>";
-		return $ret;
+		// Use the parent class render method which uses the unified template
+		// This ensures both standard and IPF checkboxes use the same template
+		return parent::render();
 	}
 
 	/**
@@ -114,6 +91,7 @@ class icms_ipf_form_elements_Checkbox extends icms_form_elements_Checkbox {
 		$js = "";
 		$js .= "var hasSelections = false;";
 		$eltname = $this->getName();
+		$eltcaption = $this->getCaption();
 		$eltmsg = empty($eltcaption) ? sprintf(_FORM_ENTER, $eltname) : sprintf(_FORM_ENTER, $eltcaption);
 		$eltmsg = str_replace('"', '\"', stripslashes($eltmsg));
 		if (strpos($eltname, '[') === false) $eltname = $eltname . "[]";

--- a/htdocs/libraries/icms/ipf/form/elements/Passwordtray.php
+++ b/htdocs/libraries/icms/ipf/form/elements/Passwordtray.php
@@ -36,9 +36,32 @@ class icms_ipf_form_elements_Passwordtray extends icms_form_elements_Tray {
 	}
 
 	public function render() {
-		$ret = parent::render();
-		$ret .= "<input type='password' name='" . $this->_key . "2' id='" . $this->_key . "2' "
-			 .  "size='10' maxlength='32' value='' autocomplete='off' />";
-		return $ret;
+		// Use template-based rendering instead of direct HTML generation
+		$this->tpl = new icms_view_Tpl();
+
+		// Get rendered elements from parent tray
+		$tray_elements = array();
+		foreach ($this->getElements() as $element) {
+			$tray_elements[] = $element->render();
+		}
+
+		// Create second password field HTML
+		$second_password_field = "<input type='password' name='" . $this->_key . "2' id='" . $this->_key . "2' "
+			. "size='10' maxlength='32' value='' autocomplete='off' />";
+
+		// Assign template variables
+		$this->tpl->assign('tray_elements', $tray_elements);
+		$this->tpl->assign('tray_delimeter', $this->getDelimeter());
+		$this->tpl->assign('second_password_field', $second_password_field);
+
+		// Use template
+		$element_html_template = 'icms_form_elements_passwordtray_display.html';
+
+		// Try file template first (for testing), then fall back to database template
+		if (file_exists(ICMS_ROOT_PATH . '/templates/' . $element_html_template)) {
+			return $this->tpl->fetch('file:' . ICMS_ROOT_PATH . '/templates/' . $element_html_template);
+		} else {
+			return $this->tpl->fetch('db:' . $element_html_template);
+		}
 	}
 }

--- a/htdocs/modules/system/templates/icms_form_elements_checkbox_display.html
+++ b/htdocs/modules/system/templates/icms_form_elements_checkbox_display.html
@@ -18,7 +18,15 @@
 		<{if !$smarty.foreach.checkbox.last}><{$ele_delimeter}><{/if}>
 		<{/foreach}>
 	<{/if}>
-	<{if $smarty.foreach.checkbox.total gt 1 }>
+
+	<{* Check All functionality - show if more than one option *}>
+	<{assign var="option_count" value=0}>
+	<{if $ele_checkbox_options}>
+		<{assign var="option_count" value=$ele_checkbox_options|@count}>
+	<{elseif $ele_options}>
+		<{assign var="option_count" value=$ele_options|@count}>
+	<{/if}>
+	<{if $option_count gt 1}>
 	<div class='icms_checkboxoption'>
 		<input type='checkbox' id='<{$ele_name}>_checkemall' class='checkemall' />
 		<label for='<{$ele_name}>_checkemall'><{$smarty.const._CHECKALL}></label>

--- a/htdocs/modules/system/templates/icms_form_elements_checkbox_display.html
+++ b/htdocs/modules/system/templates/icms_form_elements_checkbox_display.html
@@ -1,7 +1,7 @@
 <div class="grouped">
 	<{foreach from=$ele_options item=option name=checkbox}>
 	<span class="icms_checkboxoption">
-		<input type="checkbox" name="<{$ele_name}>" id="<{$ele_id}>_item_<{$smarty.foreach.checkbox.iteration}>" value="<{$smarty.foreach.checkbox.iteration}>">
+		<input type="checkbox" name="<{$ele_name}>" id="<{$ele_id}>_item_<{$smarty.foreach.checkbox.iteration}>" value="<{$smarty.foreach.checkbox.iteration}>" <{if $ele_ischecked='checked'}>checked="checked"<{/if}> >
 		<label for="<{$ele_id}>_item_<{$smarty.foreach.checkbox.iteration}>"><{$option}></label>
 	</span>
 	&nbsp;

--- a/htdocs/modules/system/templates/icms_form_elements_checkbox_display.html
+++ b/htdocs/modules/system/templates/icms_form_elements_checkbox_display.html
@@ -1,11 +1,23 @@
 <div class="grouped">
-	<{foreach from=$ele_options item=option name=checkbox}>
-	<span class="icms_checkboxoption">
-		<input type="checkbox" name="<{$ele_name}>" id="<{$ele_id}>_item_<{$smarty.foreach.checkbox.iteration}>" value="<{$smarty.foreach.checkbox.iteration}>" <{if $ele_ischecked='checked'}>checked="checked"<{/if}> >
-		<label for="<{$ele_id}>_item_<{$smarty.foreach.checkbox.iteration}>"><{$option}></label>
-	</span>
-	&nbsp;
-	<{/foreach}>
+	<{if $ele_checkbox_options}>
+		<{* Use the new unified structure if available *}>
+		<{foreach from=$ele_checkbox_options item=option name=checkbox}>
+		<span class="icms_checkboxoption">
+			<input type="checkbox" name="<{$ele_name}>" id="<{$ele_id}>_<{$option.value}>" value="<{$option.value}>" <{if $option.checked}>checked="checked"<{/if}> <{$ele_extra}> />
+			<label for="<{$ele_id}>_<{$option.value}>"><{$option.label}></label>
+		</span>
+		<{if !$smarty.foreach.checkbox.last}><{$ele_delimeter}><{/if}>
+		<{/foreach}>
+	<{else}>
+		<{* Fallback to legacy structure for backward compatibility *}>
+		<{foreach from=$ele_options key=value item=label name=checkbox}>
+		<span class="icms_checkboxoption">
+			<input type="checkbox" name="<{$ele_name}>" id="<{$ele_id}>_<{$value}>" value="<{$value}>" <{if $ele_value && in_array($value, $ele_value)}>checked="checked"<{/if}> <{$ele_extra}> />
+			<label for="<{$ele_id}>_<{$value}>"><{$label}></label>
+		</span>
+		<{if !$smarty.foreach.checkbox.last}><{$ele_delimeter}><{/if}>
+		<{/foreach}>
+	<{/if}>
 	<{if $smarty.foreach.checkbox.total gt 1 }>
 	<div class='icms_checkboxoption'>
 		<input type='checkbox' id='<{$ele_name}>_checkemall' class='checkemall' />

--- a/htdocs/modules/system/templates/icms_form_elements_passwordtray_display.html
+++ b/htdocs/modules/system/templates/icms_form_elements_passwordtray_display.html
@@ -1,0 +1,18 @@
+<{* Template for IPF password tray form element display *}>
+<{* This template creates dual password fields for password confirmation *}>
+
+<div class="password-tray">
+    <{* First password field (from tray elements) *}>
+    <{if $tray_elements}>
+        <{foreach from=$tray_elements item=element}>
+            <{$element}>
+            <{if !$smarty.foreach.default.last}><{$tray_delimeter}><{/if}>
+        <{/foreach}>
+    <{/if}>
+    
+    <{* Second password field (confirmation) *}>
+    <{if $second_password_field}>
+        <{$tray_delimeter}>
+        <{$second_password_field}>
+    <{/if}>
+</div>

--- a/htdocs/templates/icms_form_elements_checkbox_display.html
+++ b/htdocs/templates/icms_form_elements_checkbox_display.html
@@ -1,0 +1,28 @@
+<{* Template for checkbox form element display *}>
+<{* This template works with the new unified checkbox options structure *}>
+
+<{if $ele_checkbox_options}>
+    <{* Use the new unified structure if available *}>
+    <{foreach from=$ele_checkbox_options item=option}>
+        <input type="checkbox" 
+               name="<{$ele_name}>" 
+               id="<{$ele_id}>_<{$option.value}>" 
+               value="<{$option.value}>" 
+               <{if $option.checked}>checked="checked"<{/if}>
+               <{$ele_extra}> />
+        <label for="<{$ele_id}>_<{$option.value}>"><{$option.label}></label>
+        <{if !$smarty.foreach.default.last}><{$ele_delimeter}><{/if}>
+    <{/foreach}>
+<{else}>
+    <{* Fallback to legacy structure for backward compatibility *}>
+    <{foreach from=$ele_options key=value item=label}>
+        <input type="checkbox" 
+               name="<{$ele_name}>" 
+               id="<{$ele_id}>_<{$value}>" 
+               value="<{$value}>" 
+               <{if $ele_value && in_array($value, $ele_value)}>checked="checked"<{/if}>
+               <{$ele_extra}> />
+        <label for="<{$ele_id}>_<{$value}>"><{$label}></label>
+        <{if !$smarty.foreach.default.last}><{$ele_delimeter}><{/if}>
+    <{/foreach}>
+<{/if}>

--- a/htdocs/templates/icms_form_elements_checkbox_display.html
+++ b/htdocs/templates/icms_form_elements_checkbox_display.html
@@ -1,28 +1,38 @@
 <{* Template for checkbox form element display *}>
-<{* This template works with the new unified checkbox options structure *}>
+<{* This template works with both standard and IPF checkbox classes *}>
 
-<{if $ele_checkbox_options}>
-    <{* Use the new unified structure if available *}>
-    <{foreach from=$ele_checkbox_options item=option}>
-        <input type="checkbox" 
-               name="<{$ele_name}>" 
-               id="<{$ele_id}>_<{$option.value}>" 
-               value="<{$option.value}>" 
-               <{if $option.checked}>checked="checked"<{/if}>
-               <{$ele_extra}> />
-        <label for="<{$ele_id}>_<{$option.value}>"><{$option.label}></label>
-        <{if !$smarty.foreach.default.last}><{$ele_delimeter}><{/if}>
-    <{/foreach}>
-<{else}>
-    <{* Fallback to legacy structure for backward compatibility *}>
-    <{foreach from=$ele_options key=value item=label}>
-        <input type="checkbox" 
-               name="<{$ele_name}>" 
-               id="<{$ele_id}>_<{$value}>" 
-               value="<{$value}>" 
-               <{if $ele_value && in_array($value, $ele_value)}>checked="checked"<{/if}>
-               <{$ele_extra}> />
-        <label for="<{$ele_id}>_<{$value}>"><{$label}></label>
-        <{if !$smarty.foreach.default.last}><{$ele_delimeter}><{/if}>
-    <{/foreach}>
-<{/if}>
+<div class="grouped">
+	<{if $ele_checkbox_options}>
+		<{* Use the new unified structure if available *}>
+		<{foreach from=$ele_checkbox_options item=option name=checkbox}>
+		<span class="icms_checkboxoption">
+			<input type="checkbox" name="<{$ele_name}>" id="<{$ele_id}>_<{$option.value}>" value="<{$option.value}>" <{if $option.checked}>checked="checked"<{/if}> <{$ele_extra}> />
+			<label for="<{$ele_id}>_<{$option.value}>"><{$option.label}></label>
+		</span>
+		<{if !$smarty.foreach.checkbox.last}><{$ele_delimeter}><{/if}>
+		<{/foreach}>
+	<{else}>
+		<{* Fallback to legacy structure for backward compatibility *}>
+		<{foreach from=$ele_options key=value item=label name=checkbox}>
+		<span class="icms_checkboxoption">
+			<input type="checkbox" name="<{$ele_name}>" id="<{$ele_id}>_<{$value}>" value="<{$value}>" <{if $ele_value && in_array($value, $ele_value)}>checked="checked"<{/if}> <{$ele_extra}> />
+			<label for="<{$ele_id}>_<{$value}>"><{$label}></label>
+		</span>
+		<{if !$smarty.foreach.checkbox.last}><{$ele_delimeter}><{/if}>
+		<{/foreach}>
+	<{/if}>
+
+	<{* Check All functionality - show if more than one option *}>
+	<{assign var="option_count" value=0}>
+	<{if $ele_checkbox_options}>
+		<{assign var="option_count" value=$ele_checkbox_options|@count}>
+	<{elseif $ele_options}>
+		<{assign var="option_count" value=$ele_options|@count}>
+	<{/if}>
+	<{if $option_count gt 1}>
+	<div class='icms_checkboxoption'>
+		<input type='checkbox' id='<{$ele_name}>_checkemall' class='checkemall' />
+		<label for='<{$ele_name}>_checkemall'><{$smarty.const._CHECKALL}></label>
+	</div>
+	<{/if}>
+</div>

--- a/htdocs/templates/icms_form_elements_passwordtray_display.html
+++ b/htdocs/templates/icms_form_elements_passwordtray_display.html
@@ -1,0 +1,18 @@
+<{* Template for IPF password tray form element display *}>
+<{* This template creates dual password fields for password confirmation *}>
+
+<div class="password-tray">
+    <{* First password field (from tray elements) *}>
+    <{if $tray_elements}>
+        <{foreach from=$tray_elements item=element}>
+            <{$element}>
+            <{if !$smarty.foreach.default.last}><{$tray_delimeter}><{/if}>
+        <{/foreach}>
+    <{/if}>
+    
+    <{* Second password field (confirmation) *}>
+    <{if $second_password_field}>
+        <{$tray_delimeter}>
+        <{$second_password_field}>
+    <{/if}>
+</div>


### PR DESCRIPTION
The template didn't take into account the 'checked' state. 

* After reviewing the code, I refactored it to have the information in a single array with sub-values, instead of 3 different arrays that need to be consolidated in the template. 
* I added the same logic to the IPF variants of the classes so all checkboxes, password boxes, buttons and text boxes now use a single template and should look the same, whether constructed using IPF or not.
