### PR TITLE
chore:no need to check for PHP_VERSION_ID anymore

### DIFF
--- a/htdocs/install/common.inc.php
+++ b/htdocs/install/common.inc.php
@@ -30,12 +30,6 @@ define('XOOPS_INSTALL', 1);
  */
 date_default_timezone_set(@date_default_timezone_get());
 
-if (!defined('PHP_VERSION_ID')) {
-	$version = explode('.', PHP_VERSION);
-
-	define('PHP_VERSION_ID', ($version[0] * 10000 + $version[1] * 100 + $version[2]));
-}
-
 include_once '../include/version.php';
 // including a few functions - core
 include_once '../include/functions.php';
@@ -47,8 +41,6 @@ require_once '../libraries/icms/Autoloader.php';
 icms_Autoloader::setup();
 
 error_reporting(E_ALL);
-
-
 
 $pageHasHelp = false;
 $pageHasForm = false;


### PR DESCRIPTION
### **User description**
it is always there since 5.2.7


___

### **PR Type**
Other


___

### **Description**
- Remove obsolete PHP_VERSION_ID constant check

- Clean up whitespace formatting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PHP_VERSION_ID check"] -- "removed" --> B["Cleaner code"]
  B -- "whitespace cleanup" --> C["Formatted file"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>common.inc.php</strong><dd><code>Remove PHP_VERSION_ID check and cleanup formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

htdocs/install/common.inc.php

<ul><li>Removed conditional definition of <code>PHP_VERSION_ID</code> constant<br> <li> Cleaned up extra blank lines for better formatting<br> <li> Added missing newline at end of file</ul>


</details>


  </td>
  <td><a href="https://github.com/ImpressCMS/impresscms/pull/1652/files#diff-1c38091119d92fafdc0b1c9b7221fffab447813aae973076951fb21e363ce8a3">+1/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

