### PR TITLE
Add conditional rendering for theme selection selector

### DIFF
--- a/htdocs/modules/system/templates/blocks/system_block_themes.html
+++ b/htdocs/modules/system/templates/blocks/system_block_themes.html
@@ -1,11 +1,14 @@
 <div style="text-align: center;">
 <form action="index.php" method="post">
 <div>
+	<{if $block.theme_select|@count > 1}>
 	<select name="theme_select" onchange="submit();" size="3">
 	<{foreach item=theme from=$block.theme_select}>
 	<option value="<{$theme.folder}>"> <{if $theme.option>0}><img src="<{$theme.image}>"><br/><{/if}><{$theme.name}></option>
 	<{/foreach}>
 	</select>
+	<{/if}>
 </div>
 </form>
+
 </div>


### PR DESCRIPTION
### **User description**
Only render the select when there are themes available - small improvement


___

### **PR Type**
Enhancement


___

### **Description**
- Add conditional rendering for theme selector dropdown

- Only display select element when multiple themes available

- Improves UX by hiding selector with single theme


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Theme Block Template"] -- "Check theme count" --> B["Count > 1?"]
  B -- "Yes" --> C["Render Select Dropdown"]
  B -- "No" --> D["Hide Selector"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_block_themes.html</strong><dd><code>Conditionally render theme selector based on count</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

htdocs/modules/system/templates/blocks/system_block_themes.html

<ul><li>Wrapped select element with conditional check <code>{if </code><br><code>$block.theme_select|@count > 1}</code><br> <li> Only renders theme dropdown when more than one theme is available<br> <li> Improves user experience by hiding selector when no choice exists<br> <li> Fixed trailing whitespace and formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/ImpressCMS/impresscms/pull/1669/files#diff-4a2460862eca87fa6d82cf3e9b87414a7f65f5e636d8dc638ad44629be8b0f88">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

