### PR TITLE
Improve CSRF error handling in pmlite

### DIFF
--- a/htdocs/pmlite.php
+++ b/htdocs/pmlite.php
@@ -63,8 +63,13 @@ xoops_header();
 if (icms::$user) {
 	if (isset($_POST['op']) && $_POST['op'] == "submit") {
 		if (!icms::$security->check()) {
-			$security_error = true;
+			echo "<br /><br /><div><h4>" . _PM_USERNOEXIST . "<br />"
+				. _PM_PLZTRYAGAIN . "</h4><br />";
+			echo implode('<br />', icms::$security->getErrors());
+			echo "[ <a href='javascript:history.go(-1)'>" . _PM_GOBACK . "</a> ]</div>";
+			exit();
 		}
+
 		$res = icms::$xoopsDB->query("SELECT COUNT(*) FROM " . icms::$xoopsDB->prefix("users")
 			. " WHERE uid='". (int) ($_POST['to_userid']) . "'");
 		list($count) = icms::$xoopsDB->fetchRow($res);


### PR DESCRIPTION
This pull request updates htdocs/pmlite.php to display specific security error messages directly in the browser when validation fails, instead of just setting an internal flag. The code now shows a warning message with a prompt and button to return to the previous page.
* Replaced the error variable assignment with a direct HTML output for security warnings.
* Added text, an action button, and a list of detailed errors.
* No change to the existing user count query logic that follows the changes.